### PR TITLE
1.4 - cache badge images, exclude option, nolocking option

### DIFF
--- a/BadgeService/README.md
+++ b/BadgeService/README.md
@@ -1,13 +1,5 @@
 # AUniter Badge Service
 
-Status: Implementation done. However, GitHub seems to cache the badge image
-aggressively even though the response sets the `cache-control` header.
-It is not clear how long the cache lasts.
-
-Here is a test badge to find out how long GitHub caches the image:
-
-![Test Badge](https://us-central1-xparks2015.cloudfunctions.net/badge?project=test2)
-
 ## Introduction
 
 [Continuous Integration with Jenkins](../jenkins/README.md) explains that
@@ -48,7 +40,7 @@ by the locall hosted Jenkins server.
 An example might make this more clear.
 For the [AceSegment](https://github.com/bxparks/AceSegment) project,
 I created a **BadgeService** at
-https://us-central1-xparks2015.cloudfunctions.net/badge?project=AceSegment.
+https://us-central1-xparks2018.cloudfunctions.net/badge?project=AceSegment.
 This microservice looks for two files in Google Cloud Storage:
 * `gs://xparks-jenkins/AceSegment=PASSED`, or
 * `gs://xparks-jenkins/AceSegment=FAILED`.
@@ -139,7 +131,7 @@ state of the build.
     * It will needed below where you will replace `{badgeServiceUrl}` with this
     * URL.
     * The URL will will look something like
-      https://us-central1-xparks2015.cloudfunctions.net/badge.
+      https://us-central1-xparks2018.cloudfunctions.net/badge.
 1. Test the badge for a project that passes the continuous integration.
     * Create `gs://{bucketName}/test=PASSED` using the `set-badge-status.sh`
       script.
@@ -227,6 +219,16 @@ following verification:
 
 Finally, add the image Markdown tag into the README.md file of your
 project pointing to the {badgeServiceUrl}.
+
+### GitHub Caching
+
+Even though the badge image is returned with a header that disables caching of
+the image:
+```
+Cache-Control: no-cache, no-store, must-revalidate
+```
+GitHub will ignore that setting and cache the badge image anyway. Fortunately,
+the cache time period seems to be relatively short (a few hours?).
 
 ## Security, Privacy and Scalability
 

--- a/BadgeService/README.md
+++ b/BadgeService/README.md
@@ -2,7 +2,7 @@
 
 Status: Implementation done. README.md in progress.
 
-![Test Badge](https://us-central1-xparks2015.cloudfunctions.net/badge?project=test)
+![Test Badge](https://us-central1-xparks2015.cloudfunctions.net/badge?project=test2)
 
 ## Introduction
 

--- a/BadgeService/README.md
+++ b/BadgeService/README.md
@@ -2,6 +2,8 @@
 
 Status: Implementation done. README.md in progress.
 
+![Test Badge](https://us-central1-xparks2015.cloudfunctions.net/badge?project=test)
+
 ## Introduction
 
 [Continuous Integration with Jenkins](../jenkins/README.md) explains that

--- a/BadgeService/README.md
+++ b/BadgeService/README.md
@@ -1,6 +1,10 @@
 # AUniter Badge Service
 
-Status: Implementation done. README.md in progress.
+Status: Implementation done. However, GitHub seems to cache the badge image
+aggressively even though the response sets the `cache-control` header.
+It is not clear how long the cache lasts.
+
+Here is a test badge to find out how long GitHub caches the image:
 
 ![Test Badge](https://us-central1-xparks2015.cloudfunctions.net/badge?project=test2)
 

--- a/BadgeService/index.js
+++ b/BadgeService/index.js
@@ -7,7 +7,7 @@
  * on the status of the Jenkins continuous integration of a given project.
  *
  * The GET handler is at:
- *  - https://us-central1-xparks2015.cloudfunctions.net/badge?project={project}
+ *  - https://us-central1-xparks2018.cloudfunctions.net/badge?project={project}
  * The {project} is the name of the project being queried.
  *
  * It looks for a status file in Google Cloud Storage, in the given

--- a/BadgeService/index.js
+++ b/BadgeService/index.js
@@ -132,6 +132,7 @@ function fetchBadge(res, url) {
       });
       http_res.on('end', () => {
         res.type('image/svg+xml;charset=utf-8');
+        res.header('Cache-Control', 'no-cache, no-store, must-revalidate');
         res.send(data);
         resolve();
       });

--- a/BadgeService/index.js
+++ b/BadgeService/index.js
@@ -16,7 +16,7 @@
  *  - '{project}=PASSED'
  *  - '{project}=FAILED'
  *
- * There are 4 possible badges:
+ * There are 5 possible badges:
  *
  *  - If the PASSED file is detected, then a "passing" badge from shields.io is
  *    returned.
@@ -26,6 +26,7 @@
  *    returned.
  *  - If both of these markers file exist (which shouldn't happen), then
  *    an "error" badge is returned.
+ *  - If {project} is not given, then an "invalid" badge is returned.
  *
  * Deployment:
  *
@@ -41,7 +42,19 @@ const bucketName = 'xparks-jenkins';
 // Number of milliseconds between successive calls to checkPassOrFail().
 const checkIntervalMillis = 1 * 60 * 1000;
 
-const badgeBaseUrl = 'https://img.shields.io/badge/';
+// Cache of static badges from https://img.shields.io/badge/
+const badges = {
+  'build-passing-brightgreen.svg':
+      '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="88" height="20"><linearGradient id="b" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient><clipPath id="a"><rect width="88" height="20" rx="3" fill="#fff"/></clipPath><g clip-path="url(#a)"><path fill="#555" d="M0 0h37v20H0z"/><path fill="#4c1" d="M37 0h51v20H37z"/><path fill="url(#b)" d="M0 0h88v20H0z"/></g><g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110"> <text x="195" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="270">build</text><text x="195" y="140" transform="scale(.1)" textLength="270">build</text><text x="615" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="410">passing</text><text x="615" y="140" transform="scale(.1)" textLength="410">passing</text></g> </svg>',
+  'build-failure-red.svg':
+      '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="82" height="20"><linearGradient id="b" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient><clipPath id="a"><rect width="82" height="20" rx="3" fill="#fff"/></clipPath><g clip-path="url(#a)"><path fill="#555" d="M0 0h37v20H0z"/><path fill="#e05d44" d="M37 0h45v20H37z"/><path fill="url(#b)" d="M0 0h82v20H0z"/></g><g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110"> <text x="195" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="270">build</text><text x="195" y="140" transform="scale(.1)" textLength="270">build</text><text x="585" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="350">failure</text><text x="585" y="140" transform="scale(.1)" textLength="350">failure</text></g> </svg>',
+  'build-invalid-orange.svg':
+      '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="82" height="20"><linearGradient id="b" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient><clipPath id="a"><rect width="82" height="20" rx="3" fill="#fff"/></clipPath><g clip-path="url(#a)"><path fill="#555" d="M0 0h37v20H0z"/><path fill="#fe7d37" d="M37 0h45v20H37z"/><path fill="url(#b)" d="M0 0h82v20H0z"/></g><g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110"> <text x="195" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="270">build</text><text x="195" y="140" transform="scale(.1)" textLength="270">build</text><text x="585" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="350">invalid</text><text x="585" y="140" transform="scale(.1)" textLength="350">invalid</text></g> </svg>',
+  'build-error-yellow.svg':
+      '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="74" height="20"><linearGradient id="b" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient><clipPath id="a"><rect width="74" height="20" rx="3" fill="#fff"/></clipPath><g clip-path="url(#a)"><path fill="#555" d="M0 0h37v20H0z"/><path fill="#dfb317" d="M37 0h37v20H37z"/><path fill="url(#b)" d="M0 0h74v20H0z"/></g><g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110"> <text x="195" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="270">build</text><text x="195" y="140" transform="scale(.1)" textLength="270">build</text><text x="545" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="270">error</text><text x="545" y="140" transform="scale(.1)" textLength="270">error</text></g> </svg>',
+  'build-unknown-lightgrey.svg':
+      '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="98" height="20"><linearGradient id="b" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient><clipPath id="a"><rect width="98" height="20" rx="3" fill="#fff"/></clipPath><g clip-path="url(#a)"><path fill="#555" d="M0 0h37v20H0z"/><path fill="#9f9f9f" d="M37 0h61v20H37z"/><path fill="url(#b)" d="M0 0h98v20H0z"/></g><g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110"> <text x="195" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="270">build</text><text x="195" y="140" transform="scale(.1)" textLength="270">build</text><text x="665" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="510">unknown</text><text x="665" y="140" transform="scale(.1)" textLength="510">unknown</text></g> </svg>',
+};
 
 // Cache of various meta-info related to the CI status of particular project.
 var projectInfos = {};
@@ -71,7 +84,7 @@ function updateProjectInfos(files) {
 /**
  * Return the badge URI fragment of the project using the projectInfos cache.
  */
-function getUri(project) {
+function getBadgeForProject(project) {
   if (project == null) {
     return 'build-invalid-orange.svg';
   }
@@ -96,52 +109,12 @@ function getUri(project) {
   }
 }
 
-/**
- * Fetch the shields.io badge and echo it back to res. I tried using a 307
- * redirect, but shields.io returns a response with "cache-control:
- * max-age=86400" for static badges, which causes GitHub to cache the badge for
- * 1 whole day. To bypass the cache-control, we fetch it ourselves, then proxy
- * the image back the requester. Our header is set to "cache-control: no-cache,
- * must-revalidate" which is enough to prevent GitHub from permanently caching
- * that image. I also notice an "etag" header being set. That must be set
- * automatically by the Google Frontend in front of this service.
- *
- * For explanation of the https.get() and Promise chaining, see:
- *
- *  - https://nodejs.org/docs/latest/api/https.html.
- *  - https://javascript.info/promise-chaining
- *  - https://valentinog.com/blog/http-requests-node-js-async-await/
- */
-function fetchBadge(res, url) {
-  return new Promise((resolve, reject) => {
-    var https = require('https');
-
-    https.get(url, (http_res) => {
-      const { statusCode } = http_res;
-      if (statusCode !== 200) {
-        console.log('fetchBadge(): statusCode: ', statusCode, '; url: ', url);
-        http_res.resume();
-        res.status(404).end();
-        resolve();
-        return;
-      }
-
-      var data = '';
-      http_res.on('data', (chunk) => {
-        data += chunk;
-      });
-      http_res.on('end', () => {
-        res.type('image/svg+xml;charset=utf-8');
-        res.header('Cache-Control', 'no-cache, no-store, must-revalidate');
-        res.send(data);
-        resolve();
-      });
-    }).on('error', e => {
-      console.error('ERROR: ', err);
-      res.status(500).end();
-      reject();
-    });
-  });
+/** Send the image corresponding to 'badge'. */
+function sendBadgeImage(res, badge) {
+  const badgeImage = badges[badge];
+  res.type('image/svg+xml;charset=utf-8');
+  res.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+  res.send(badgeImage);
 }
 
 /**
@@ -159,16 +132,17 @@ function fetchBadge(res, url) {
  */
 exports.badge = (req, res) => {
   const project = req.query.project;
-  if (project == null) {
-    return fetchBadge(res, badgeBaseUrl + 'build-invalid-orange.svg');
+  if (!project) {
+    sendBadgeImage(res, 'build-invalid-orange.svg');
+    return;
   }
   console.log('badge(): Processing project: ', project);
 
   // Use the cache if it was updated recently.
   const nowMillis = new Date().getTime();
   if (nowMillis - lastCheckedTime <= checkIntervalMillis) {
-    const uri = getUri(project);
-    return fetchBadge(res, badgeBaseUrl + uri);
+    sendBadgeImage(res, getBadgeForProject(project));
+    return;
   }
 
   const Storage = require('@google-cloud/storage');
@@ -182,8 +156,7 @@ exports.badge = (req, res) => {
         const files = results[0];
         updateProjectInfos(files);
         lastCheckedTime = nowMillis;
-        const uri = getUri(project);
-        return fetchBadge(res, badgeBaseUrl + uri);
+        sendBadgeImage(res, getBadgeForProject(project));
       })
       .catch(err => {
         console.error('ERROR: ', err);

--- a/BadgeService/index.js
+++ b/BadgeService/index.js
@@ -88,7 +88,7 @@ function getUri(project) {
       }
     } else {
       if (projectInfo.failedFound) {
-        return 'build-failure-brightred.svg';
+        return 'build-failure-red.svg';
       } else {
         return 'build-unknown-lightgrey.svg';
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+* 1.4 (2018-08-16)
+    * Reduce latency of BadgeService using statically cached images
+      from shields.io.
+    * Add proper cache-control directive in BadgeService to prevent GitHub
+      from caching badges too aggressively.
+    * Add --exclude option to allow some boards to skip some sketches which
+      don't compile for those targets.
+    * Add --nolocking option to avoid flock(1) for Leonardo/Mciro boards
+      which use virtual serial ports. (Fixes #9)
+    * Add new [options] section to the auniter.conf file format.
 * 1.3 (2018-07-21)
     * Add BadgeService implemented using Google Functions to allow a locally
       hosted Jenkins to determine the shields.io that can be displayed in

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ There are 3 components to the **AUniter** package:
    locally hosted Jenkins system to update the status of the build, so that an
    indicator badge can be displayed on a source control repository like GitHub.
 
-Version: 1.3 (2018-07-21)
+Version: 1.4 (2018-08-16)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ so I do not know if it would work on that.
 ## Limitations
 
 * [Teensyduino](https://pjrc.com/teensy/teensyduino.html) is not supported
-  due to Issue #4.
+  due to [Issue #4](https://github.com/bxparks/AUniter/issues/4).
 
 ## License
 

--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -91,7 +91,7 @@ preferences, the `preferences.txt` file is saved with its file mode set to
 `600`, which prevents any other user on the computer from accessing that
 preferences file.)
 
-We are make some changes to the instructions for installing the
+We make some changes to the instructions for installing the
 [Arduino IDE on Linux](https://www.arduino.cc/en/Guide/Linux), because
 we will install it as a
 [Portable IDE](https://www.arduino.cc/en/Guide/PortableIDE) into
@@ -105,7 +105,7 @@ like `/home/{yourusername}/Downloads/arduino-1.8.5-linux64.tar.xz`.
 (`/var/lib/jenkins`):
 ```
 $ sudo -i -u jenkins
-jenkins$ tar -xf * /home/{yourusername}/Downloads/arduino-1.8.5-linux64.tar.xz
+jenkins$ tar -xf /home/{yourusername}/Downloads/arduino-1.8.5-linux64.tar.xz
 jenkins$ cd arduino-1.8.5
 jenkins$ mkdir portable
 ```

--- a/tools/README.md
+++ b/tools/README.md
@@ -276,7 +276,7 @@ It did not seem worth providing aliases for the ports in the
 `$HOME/.auniter.conf` file because the specific serial port is assigned by the
 OS and can vary depending on the presence of other USB or serial devices.
 
-### Mutually Exclusive Access
+### Mutually Exclusive Access (--locking, --nolocking)
 
 Multiple instances of the `auniter.sh` script can be executed, which can help
 with the `--verify` operation if you have multiple CPU cores. However, when the
@@ -296,7 +296,7 @@ By default, the locking is performed. There are 2 ways to disable the locking:
 1) Use the `--[no]locking` flag on the `auniter.sh` script.
 
 2) Add an entry for a specific board alias under the `[options]` section in the
-  `CONFIG_FILE`. The format looking like this:
+  `CONFIG_FILE`. The format looks like this:
 ```
 [boards]
   leonardo = arduino:avr:leonardo
@@ -308,6 +308,42 @@ By default, the locking is performed. There are 2 ways to disable the locking:
 If the flag is given in both places, then the the command line flag takes
 precedence over the `CONFIG_FILE` to allow overriding of the value in the config
 file.
+
+### Excluding Files (--exclude regexp)
+
+Some programs cannot be compiled under some microcontroller boards.
+The `--exclude regexp` option will skip any `*.ino` files whose fullpath
+matches the regular expression used by
+[egrep](https://linux.die.net/man/1/egrep).
+
+This flag is intended to be used in the `[options]` section of the
+`CONFIG_FILE` for a given board target, like this:
+```
+[boards]
+  esp8266 = ...
+  esp32 = ...
+
+[options]
+  esp8266 = --exclude AceButton/examples/CapacitiveButton
+  esp32 = --exclude AceButton/examples/CapacitiveButton
+```
+
+The `CapacitiveButton` program does not compile for ESP8266 or ESP32 boards.
+This entry in the `CONFIG_FILE` will cause `auniter.sh` to skip this file for
+all modes (verify, upload, test, monitor).
+
+Multiple files can be specified using the `a|b` regular expression:
+```
+  esp8266 = --exclude AceButton/examples/CapacitiveButton|AceButton/examples/StopWatch
+```
+
+If the flag is given to the `auniter.sh` script explicitly, it will override
+the value in `CONFIG_FILE`. Therefore, you can explicitly compile a program
+that is excluded from the `CONFIG_FILE` by giving a regexp which matches
+nothing. For example:
+```
+$ ./auniter.sh --exclude none --boards esp8266 CapacitiveButton
+```
 
 ## Integration with Jenkins
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -186,19 +186,6 @@ $ ./auniter.sh --list_ports
 /dev/ttyACM0 - Arduino Leonardo
 ```
 
-### Mutually Exclusive Access
-
-Multiple instances of the `auniter.sh` script can be executed, which can help
-with the `--verify` operation if you have multiple CPU cores. However, when the
-`--upload` or `--test` mode is selected, it is important to ensure that only one
-instance of the Arduino IDE uploads and/or monitors the serial port at given
-time. Otherwise one instance of the `auniter.sh` script can accidentally
-see the output of another `auniter.sh` and cause confusion.
-
-The `auniter.sh` script uses a locking mechanism on the serial port of the
-Arduino board to prevent multiple uploads to and serial monitoring of the same
-Arduino board at the same time.
-
 ### Automatic Directory Expansion
 
 If the `auniter.sh` is given a directory `dir`, it tries to find
@@ -227,9 +214,9 @@ espressif:esp32:esp32:PartitionScheme=default,FlashMode=qio,FlashFreq=80,FlashSi
 It is likely that not all the extra parameters are needed, but it is not
 easy to figure out which ones can be left out.
 
-Instead of using the `fqbn`, the `auniter.sh` script allows
-the user to define aliases for the `fqbn` in a file. The format of the file is
-the [INI file](https://en.wikipedia.org/wiki/INI_file), and the aliases are
+Instead of using the `fqbn`, the `auniter.sh` script allows the user to define
+aliases for the `fqbn` in a file. The format of the file is the
+[INI file](https://en.wikipedia.org/wiki/INI_file), and the aliases are
 in the `[boards]` section:
 ```
 # Board aliases
@@ -246,7 +233,8 @@ limited to the usual character set for identifiers (`a-z`, `A-Z`, `0-9`,
 underscore `_`). It definitely cannot contain an equal sign `=` or space
 character.
 
-The board aliases can be saved into the AUniter config file.
+The board aliases can be saved into the AUniter config file. They can be
+referenced using the `--boards` flag.
 
 ### Config File (--config)
 
@@ -287,6 +275,39 @@ This runs the 5 unit tests on 4 boards connected to the ports specified by the
 It did not seem worth providing aliases for the ports in the
 `$HOME/.auniter.conf` file because the specific serial port is assigned by the
 OS and can vary depending on the presence of other USB or serial devices.
+
+### Mutually Exclusive Access
+
+Multiple instances of the `auniter.sh` script can be executed, which can help
+with the `--verify` operation if you have multiple CPU cores. However, when the
+`--upload` or `--test` mode is selected, it is important to ensure that only one
+instance of the Arduino IDE uploads and/or monitors the serial port at given
+time. Otherwise one instance of the `auniter.sh` script can accidentally
+see the output of another `auniter.sh` and cause confusion.
+
+The `auniter.sh` script uses a locking mechanism on the serial port of the
+Arduino board (using the [flock(1)](https://linux.die.net/man/1/flock) command)
+to prevent multiple uploads to and monitoring of the same Arduino board
+at the same time. Unfortunately, the locking does not work for the Pro Micro or
+Leonardo boards (using ATmega32U4) which use virtual serial ports.
+
+By default, the locking is performed. There are 2 ways to disable the locking:
+
+1) Use the `--[no]locking` flag on the `auniter.sh` script.
+
+2) Add an entry for a specific board alias under the `[options]` section in the
+  `CONFIG_FILE`. The format looking like this:
+```
+[boards]
+  leonardo = arduino:avr:leonardo
+
+[options]
+  leonardo = --nolocking
+```
+
+If the flag is given in both places, then the the command line flag takes
+precedence over the `CONFIG_FILE` to allow overriding of the value in the config
+file.
 
 ## Integration with Jenkins
 

--- a/tools/auniter.sh
+++ b/tools/auniter.sh
@@ -199,6 +199,7 @@ function process_boards() {
 
 function process_options() {
     echo "Process options: $*"
+    locking=0
     while [[ $# -gt 0 ]]; do
         case $1 in
             --locking) locking=1 ;;

--- a/tools/auniter.sh
+++ b/tools/auniter.sh
@@ -371,8 +371,7 @@ while [[ $# -gt 0 ]]; do
         --pref) shift; prefs="$prefs --pref $1" ;;
         --port_timeout) shift; port_timeout=$1 ;;
         --skip_if_no_port) skip_if_no_port=1 ;;
-        --nolocking) options="$options --nolocking" ;;
-        --locking) options="$options --locking" ;;
+        --locking|--nolocking) options="$options $1" ;;
         -*) echo "Unknown option '$1'"; usage ;;
         *) break ;;
     esac


### PR DESCRIPTION
* 1.4 (2018-08-16)
    * Reduce latency of BadgeService using statically cached images
      from shields.io.
    * Add proper cache-control directive in BadgeService to prevent GitHub
      from caching badges too aggressively.
    * Add --exclude option to allow some boards to skip some sketches which
      don't compile for those targets.
    * Add --nolocking option to avoid flock(1) for Leonardo/Mciro boards
      which use virtual serial ports. (Fixes #9)
    * Add new [options] section to the auniter.conf file format.
