### PR TITLE
1.4.1 - fix default locking, enable short port names

### DIFF
--- a/BadgeService/README.md
+++ b/BadgeService/README.md
@@ -35,7 +35,7 @@ project. The state of the build is stored as zero-length files on
 (Google's file system in the cloud). These files can be created and
 modified by a shell script (`set-badge-status.sh`) which can be called from a
 [Jenkinsfile](https://jenkins.io/doc/book/pipeline/jenkinsfile/)
-by the locall hosted Jenkins server.
+by the locally hosted Jenkins server.
 
 An example might make this more clear.
 For the [AceSegment](https://github.com/bxparks/AceSegment) project,
@@ -71,18 +71,20 @@ Here's a dependency diagram which might make this more clear:
                    /        \
                   |          \
                   |       Google Functions
-                  |       BadgeService (statically cached images)
+                  |       BadgeService
                   |             ^
-        firewall  |             |
-=========================       | (GET badge image)
                   |             |
+                  |             | (GET badge image)
+                  |             |
+                  |       GitHub/README.md
+     firewall     |             ^
+=========================       |
                   |             |
   (create/remove  |             |
-   marker files)  |         GitHub/README.md
-                  |             ^
+   marker files)  |             |
+                  |             |
      set-badge-status.sh        |
                   ^             |
-                  |             |
 Arduino board     |             | (GET)
         ^         |             |
          \        |             |
@@ -152,7 +154,7 @@ state of the build.
         * `$ ./set-badge-script.sh {bucketName} test FAILED`
     * Goto https://{badgeServiceUrl}?project=test.
     * Verify that you see a red badge.
-1. Insert `![Alt Text](https://{badgeServiceUrle}?project={project}]` in
+1. Insert `![Alt Text](https://{badgeServiceUrl}?project={project}]` in
    README.md file. (You can replace "Alt Text" with something descriptive
    about your project status.)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+* 1.4.1 (2018-09-03)
+    * Fix bug which disabled --locking by default.
+    * Allow serial port specifier in --boards flag to omit "/dev/tty" prefix.
 * 1.4 (2018-08-16)
     * Reduce latency of BadgeService using statically cached images
       from shields.io.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,16 @@ so I do not know if it would work on that.
 
 [MIT License](https://opensource.org/licenses/MIT)
 
+## Feedback and Support
+
+If you have any questions, comments, bug reports, or feature requests, please
+file a GitHub ticket or send me an email. I'd love to hear about how this
+software and its documentation can be improved. Instead of forking the
+repository to modify or add a feature for your own projects, let me have a
+chance to incorporate the change into the main repository so that your external
+dependencies are simpler and so that others can benefit. I can't promise that I
+will incorporate everything, but I will give your ideas serious consideration.
+
 ## Authors
 
 * Created by Brian T. Park (brian@xparks.net).

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ There are 3 components to the **AUniter** package:
    build, so that an indicator badge can be displayed on a source control
    repository like GitHub.
 
-Version: 1.4 (2018-08-16)
+Version: 1.4.1 (2018-09-03)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@ There are 3 components to the **AUniter** package:
 1. Command line tools (`tools/`) that can compile and upload Arduino programs
    to microcontroller boards programmatically.
 1. Integration with a locally hosted Jenkins system (`jenkins/`).
-1. A badge service (`BadgeService/`) running on Google Functions that allows the
-   locally hosted Jenkins system to update the status of the build, so that an
-   indicator badge can be displayed on a source control repository like GitHub.
+1. A badge service (`BadgeService/`) running on
+   [Google Cloud Functions](https://cloud.google.com/functions/)
+   that allows the locally hosted Jenkins system to update the status of the
+   build, so that an indicator badge can be displayed on a source control
+   repository like GitHub.
 
 Version: 1.4 (2018-08-16)
 

--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -510,6 +510,25 @@ To update the board managers, use the Arduino IDE in the same way:
 * Select "Type > Updatable".
 * Click "Update" on each board manager that needs to be updated.
 
+## Troubleshooting
+
+### Failure to Upload Due to Arduino IDE Serial Monitor
+
+The `auniter.sh` script tries to prevent multiple instance of the `Arduino`
+command line binary from accessing the same board, on the same `/dev/tty*`
+serial port, at the same time. However, if you have an Arduino IDE running on
+the same machine, and it has a serial monitor open, the `auniter.sh` script will
+not be able to obtain an exclusive lock on the serial port. The Jenkins script
+will fail on the `Test` stage when it fails to upload the program to the Arduino
+board.
+
+### Failure to add New Library Dependency
+
+When a new library is added as a dependency, the Arduino IDE will pick it up
+automatically after the library is added through the Library Manager. However,
+the Jenkins server will not pick up the new library unless it is explicitly
+added to the project's `Jenkinsfile`.
+
 ## Additional Features
 
 ### Adjust Number of Executors

--- a/tools/README.md
+++ b/tools/README.md
@@ -215,7 +215,7 @@ It is likely that not all the extra parameters are needed, but it is not
 easy to figure out which ones can be left out.
 
 Instead of using the `fqbn`, the `auniter.sh` script allows the user to define
-aliases for the `fqbn` in a file. The format of the file is the
+aliases for the `fqbn` in a config file. The format of the file is the
 [INI file](https://en.wikipedia.org/wiki/INI_file), and the aliases are
 in the `[boards]` section:
 ```
@@ -233,8 +233,9 @@ limited to the usual character set for identifiers (`a-z`, `A-Z`, `0-9`,
 underscore `_`). It definitely cannot contain an equal sign `=` or space
 character.
 
-The board aliases can be saved into the AUniter config file. They can be
-referenced using the `--boards` flag.
+The board alias can be used with the `--boards` flag (not to be confused with
+the `--board` flag which is passed directly to the Arduino binary). The
+`--boards` flag is described below.
 
 ### Config File (--config)
 
@@ -272,9 +273,18 @@ $ ./auniter.sh --test \
 This runs the 5 unit tests on 4 boards connected to the ports specified by the
 `--boards` flag.
 
-It did not seem worth providing aliases for the ports in the
-`$HOME/.auniter.conf` file because the specific serial port is assigned by the
-OS and can vary depending on the presence of other USB or serial devices.
+There are no provision for creating aliases for the ports in the
+`$HOME/.auniter.conf` file because the serial port is assigned by the OS and can
+vary depending on the presence of other USB or serial devices. However, the
+serial ports on Linux boxes always seem to start with a '/dev/tty' prefix. If a
+port in the `--boards` flag does not start with a `/` character, we assume that
+it is a shorthand and automatically prepend the `/dev/tty` prefix. The example
+above can be typed as:
+```
+$ ./auniter.sh --test \
+  --boards nano:USB0,leonardo:ACM0,esp8266:USB2,esp32:USB1 \
+  CommonTest DriverTest LedMatrixTest RendererTest WriterTest
+```
 
 ### Mutually Exclusive Access (--locking, --nolocking)
 

--- a/tools/auniter.sh
+++ b/tools/auniter.sh
@@ -220,8 +220,8 @@ function process_boards() {
 
 function process_options() {
     echo "Process options: $*"
-    locking=0
-    exclude='^$'
+    locking=1 # lock serial port using flock(1) by default
+    exclude='^$' # exclude files by default
     while [[ $# -gt 0 ]]; do
         case $1 in
             --locking) locking=1 ;;

--- a/tools/auniter.sh
+++ b/tools/auniter.sh
@@ -168,13 +168,15 @@ function process_sketches() {
     fi
 }
 
+# Requires $boards to define the target environments as a comma-separated list
+# of {board}:{port}.
 function process_boards() {
-    local alias_ports=$(echo "$boards" | sed -e 's/,/ /g')
-    for alias_port in $alias_ports; do
+    local board_and_ports=$(echo "$boards" | sed -e 's/,/ /g')
+    for board_and_port in $board_and_ports; do
         # Split {alias}:{port} into two fields.
-        local board_alias=$(echo $alias_port \
+        local board_alias=$(echo $board_and_port \
                 | sed -E -e 's/([^:]*):?([^:]*)/\1/')
-        local board_port=$(echo $alias_port \
+        local board_port=$(echo $board_and_port \
                 | sed -E -e 's/([^:]*):?([^:]*)/\2/')
 
         echo "======== Processing board=$board_alias, port=$board_port"
@@ -202,7 +204,16 @@ function process_boards() {
         process_options $config_options $options
 
         board=$board_value
-        port=$board_port
+
+        # If a port is not fully qualified (i.e. start with /), then append
+        # "/dev/tty" to the given port. On Linux, all serial ports seem to start
+        # with this prefix, so we can specify "/dev/ttyUSB0" as just "USB0".
+        if [[ $board_port =~ ^/ ]]; then
+            port=$board_port
+        else
+            port="/dev/tty$board_port"
+        fi
+
         process_files "$@"
     done
 }
@@ -221,6 +232,7 @@ function process_options() {
     done
 }
 
+# Requires $board and $port to define the target environment.
 function process_files() {
     local file
     for file in "$@"; do
@@ -241,6 +253,7 @@ function process_files() {
     done
 }
 
+# Requires $board and $port to define the target environment.
 function process_file() {
     local file=$1
     echo "==== Processing $file"


### PR DESCRIPTION
* 1.4.1 (2018-09-03)
    * Fix bug which disabled --locking by default.
    * Allow serial port specifier in --boards flag to omit "/dev/tty" prefix.
