### PR TITLE
1.5 - simplify auniter.sh interactive flags by using subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+* 1.5 (2018-09-03)
+    * Use subcommands instead of flags in auniter.sh to simplify the
+      common interactive use cases.
 * 1.4.1 (2018-09-03)
     * Fix bug which disabled --locking by default.
     * Allow serial port specifier in --boards flag to omit "/dev/tty" prefix.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ There are 3 components to the **AUniter** package:
    build, so that an indicator badge can be displayed on a source control
    repository like GitHub.
 
-Version: 1.4.1 (2018-09-03)
+Version: 1.5 (2018-09-03)
 
 ## Installation
 

--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -252,7 +252,7 @@ purposes of this tutorial, I will assume that you have an Arduino UNO.
     * In the "Default Value", enter "uno:/dev/ttyACM0".
 
 This is the value that is passed into the `--boards {alias}[:{port}],...` flag
-of the `auniter.sh` script. Use the `auniter.sh --list_ports` command if you
+of the `auniter.sh` script. Use the `auniter.sh ports` command if you
 need to.
 
 ![Boards Parameter](BoardsParameter.png)
@@ -316,7 +316,7 @@ The `AceButton/tests/Jenkinsfile` file contains 4 stages:
 * `Test`: upload `AceButton/tests/*Test` to an Arduino UNO board connected
   to `/dev/ttyACM0`, run the AUnit tests, and verify that they pass or fail
 
-Normally, you would first verify that the `auniter.sh --test` works
+Normally, you would first verify that the `auniter.sh test` command works
 successfully when you run it on the commmand line. If it works on the
 command line, then Jenkins should be able to use the same command in the
 `Jenkinsfile`.
@@ -348,28 +348,31 @@ pipeline {
         }
         stage('Verify Examples') {
             steps {
-                sh "AUniter/auniter.sh --verify \
-                    --pref sketchbook.path=$WORKSPACE \
+                sh "AUniter/auniter.sh \
                     --config libraries/AceButton/tests/auniter.conf \
+                    verify \
+                    --pref sketchbook.path=$WORKSPACE \
                     --boards $BOARDS \
                     libraries/AceButton/examples/*"
             }
         }
         stage('Verify Tests') {
             steps {
-                sh "AUniter/auniter.sh --verify \
-                    --pref sketchbook.path=$WORKSPACE \
+                sh "AUniter/auniter.sh \
                     --config libraries/AceButton/tests/auniter.conf \
+                    verify \
+                    --pref sketchbook.path=$WORKSPACE \
                     --boards $BOARDS \
                     libraries/AceButton/tests/AceButtonTest"
             }
         }
         stage('Test') {
             steps {
-                sh "AUniter/auniter.sh --test \
+                sh "AUniter/auniter.sh \
+                    --config libraries/AceButton/tests/auniter.conf \
+                    test \
                     --skip_if_no_port \
                     --pref sketchbook.path=$WORKSPACE \
-                    --config libraries/AceButton/tests/auniter.conf \
                     --boards $BOARDS \
                     libraries/AceButton/tests/AceButtonTest"
             }
@@ -397,7 +400,7 @@ with the "This project is parameterized" checkbox option.
 
 Sometimes you may want to verify compiliation against multiple boards but you
 don't have all of them connected to your serial ports. If you use the
-`--skip_if_no_port` flag with the `--test` flag, the absence of a port in the
+`--skip_if_no_port` flag with the `test` command, the absence of a port in the
 `{alias}:{port}` pair of the `$BOARDS` parameter means that the test (hence, the
 upload) should be skipped for that particular board. For example, if `$BOARDS`
 is set to `nano:/dev/ttyUSB0,leonardo,esp8266,esp32`, that means that only an
@@ -549,10 +552,11 @@ Fortunately, the `auniter.sh` script uses the `flock(1)` mechanism to allow only
 a single Arduino binary to upload to a given Arduino board at the same time. The
 second executor that tries to upload a sketch will wait up to 120 seconds for
 the Arduino board to finish its "upload/test" cycle. The locking happens only
-for the `--upload` mode. There is no locking for the `--verify` mode which
-allows multiple pipelines to verify multiple sketches at the same time, limited
-only by CPU and memory. The default wait time of 120 seconds can be overridden
-using the `--port_timeout` flag on the `auniter.sh` script.
+for the `auniter.sh upload` or `auniter.sh test` command. There is no locking
+for the `verify` command which allows multiple pipelines to verify multiple
+sketches at the same time, limited only by CPU and memory. The default wait time
+of 120 seconds can be overridden using the `--port_timeout` flag on the
+`auniter.sh` script.
 
 ### Trigger Build When Something Changes
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -85,20 +85,24 @@ esac
 ```
 (The script does not yet work on MacOS.)
 
-I also recommend creating an alias for the `auniter.sh` script in your `.bashrc`
-file if you use it often:
+### Shell Alias
+
+I recommend creating an alias for the `auniter.sh` script in your `.bashrc`
+file:
 ```
 alias auniter='{path-to-AUniter-directory}/tools/auniter.sh'
 ```
-(Don't add `{path-to-AUniter-directory}/tools` to your `$PATH`. It won't work
+Don't add `{path-to-AUniter-directory}/tools` to your `$PATH`. It won't work
 because `auniter.sh` needs to know its own install directory to find helper
-scripts.)
+scripts.
+
+*(The rest of the document will assume that you  have created this alias.)*
 
 ## Usage
 
-Type `auniter.sh --help` to get the latest usage:
+Type `auniter --help` to get the latest usage:
 ```
-$ ./auniter.sh --help
+$ auniter --help
 Usage: auniter.sh [auniter_flags] command [command_flags] [boards] [files...]
     auniter.sh verify {board} files ...
     auniter.sh upload {board:port} files ...
@@ -135,9 +139,9 @@ The following examples (all equivalent) verify that the `Blink.ino` sketch
 compiles. The `--port` flag is not necessary in this case:
 
 ```
-$ ./auniter.sh verify --board arduino:avr:nano:cpu=atmega328old Blink.ino
-$ ./auniter.sh verify --boards nano Blink.ino
-$ ./auniter.sh verify nano Blink.ino
+$ auniter verify --board arduino:avr:nano:cpu=atmega328old Blink.ino
+$ auniter verify --boards nano Blink.ino
+$ auniter verify nano Blink.ino
 ```
 
 ### Upload
@@ -146,20 +150,20 @@ To upload the sketch to the Arduino board, we need to provide the `--port`
 flag. The following examples are all equivalent:
 
 ```
-$ ./auniter.sh upload --port /dev/ttyUSB0 \
+$ auniter upload --port /dev/ttyUSB0 \
     --board arduino:avr:nano:cpu=atmega328old Blink.ino
-$ ./auniter.sh upload --boards nano:USB0 Blink.ino
-$ ./auniter.sh upload nano:USB0 Blink.ino
+$ auniter upload --boards nano:USB0 Blink.ino
+$ auniter upload nano:USB0 Blink.ino
 ```
 
 ### Test
 
 To run the AUnit test and verify pass or fail:
 ```
-$ ./auniter.sh test --port /dev/ttyUSB0 \
+$ auniter test --port /dev/ttyUSB0 \
     --board arduino:avr:nano:cpu=atmega328old tests/*Test
-$ ./auniter.sh test --boards nano:USB0 tests/*Test
-$ ./auniter.sh test nano:USB0 tests/*Test
+$ auniter test --boards nano:USB0 tests/*Test
+$ auniter test nano:USB0 tests/*Test
 ```
 
 A summary of all the test runs are given at the end, like this:
@@ -181,7 +185,7 @@ The `ALL PASSED` indicates that all unit tests passed.
 
 The `ports` command lists the available serial ports:
 ```
-$ ./auniter.sh ports
+$ auniter ports
 /dev/ttyS4 - n/a
 /dev/ttyS0 - ttyS0
 /dev/ttyUSB2 - CP2102 USB to UART Bridge Controller
@@ -254,7 +258,7 @@ file.) This may be useful if the config file is checked into source control for
 each Arduino project.
 
 ```
-$ ./auniter.sh --config {path-to-config-file} subcommand {board:port} ...
+$ auniter --config {path-to-config-file} subcommand {board:port} ...
 ```
 
 ### Multiple Boards
@@ -262,13 +266,13 @@ $ ./auniter.sh --config {path-to-config-file} subcommand {board:port} ...
 The `--boards` flag accepts a comma-separated list of `{alias}[:{port}]` pairs.
 
 ```
-$ ./auniter.sh verify nano,leonardo,esp8266,esp32 BlinkTest.ino
+$ auniter verify nano,leonardo,esp8266,esp32 BlinkTest.ino
 ```
 
 If you want to run the AUnit tests on multiple boards, you must provide the
 port of each board, like this:
 ```
-$ ./auniter.sh test \
+$ auniter test \
     nano:USB0,leonardo:ACM0,esp8266:USB2,esp32:USB1 \
   CommonTest DriverTest LedMatrixTest RendererTest WriterTest
 ```
@@ -296,7 +300,7 @@ By default, the locking is performed. There are 2 ways to disable the locking:
 
 1) Use the `--[no]locking` flag on the `auniter.sh` script.
 ```
-$ ./auniter.sh test --nolocking leonardo:USB0 tests/*Test
+$ auniter test --nolocking leonardo:USB0 tests/*Test
 ```
 
 2) Add an entry for a specific board alias under the `[options]` section in the
@@ -346,7 +350,7 @@ the value in `CONFIG_FILE`. Therefore, you can explicitly compile a program
 that is excluded from the `CONFIG_FILE` by giving a regexp which matches
 nothing. For example:
 ```
-$ ./auniter.sh --exclude none --boards esp8266 CapacitiveButton
+$ auniter --exclude none --boards esp8266 CapacitiveButton
 ```
 
 ## Integration with Jenkins

--- a/tools/auniter.sh
+++ b/tools/auniter.sh
@@ -60,11 +60,11 @@ Command Flags:
         Set the Arduino commandline preferences. Multiple flags may be given.
         Useful in continuous integration.
     --skip_if_no_port
-        (test, upload command) Just perform a --verify if --port or {:port}
+        (test, upload) Just perform a 'verify' if --port or {:port}
         is missing. Useful in Continuous Integration on multiple boards where
         only some boards are actually connected to a serial port.
     --[no]locking
-        (test command) Use (or not use) flock(1) to lock the tty for the board.
+        (test) Use (or not use) flock(1) to lock the tty for the board.
         Needed for Arduino Pro Micro, Leonardo or other boards using virtual
         serial ports. Can be set in the [options] section of the CONFIG_FILE.
     --exclude regexp
@@ -265,7 +265,7 @@ function process_file() {
     fi
 
     if [[ "$mode" == 'verify' ]]; then
-        # Allow multiple --verify commands to run at the same time.
+        # Allow multiple verify commands to run at the same time.
         $DIRNAME/run_arduino.sh \
             --verify \
             --board $board \


### PR DESCRIPTION
* 1.5 (2018-09-03)
    * Use subcommands instead of flags in auniter.sh to simplify the
      common interactive use cases.
