### PR TITLE
merge v1.8 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
     * Auto-detect the location of 'auniter.ini' in the following order:
       `--config` flag, the current directory, any parent directory,
       `$HOME/auniter.ini`, and finally `$HOME/.auniter.ini`.
+    * Add `config` command to print the auto-detected `auniter.ini` file.
+    * Add support for [arduino-cli](https://github.com/arduino/arduino-cli)
+      using the `AUNITER_ARDUINO_CLI` environment variable. The `preprocessor`
+      directive in the `auniter.ini` must not contain a string due to a bug in
+      `arduino-cli`.
+    * Add better support and testing on MacOS 10.14 (Mojave).
 * 1.7.2 (2020-08-21)
     * Look for a `*.ino` file in the current directory if no sketch file is
       specified for auniter.sh.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 * Unreleased
+    * Auto-detect the location of 'auniter.ini' in the following order:
+      `--config` flag, the current directory, any parent directory,
+      `$HOME/auniter.ini`, and finally `$HOME/.auniter.ini`.
 * 1.7.2 (2020-08-21)
     * Look for a `*.ino` file in the current directory if no sketch file is
       specified for auniter.sh.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Changelog
 
 * Unreleased
+* 1.8 (2020-09-04)
     * Auto-detect the location of 'auniter.ini' in the following order:
       `--config` flag, the current directory, any parent directory,
       `$HOME/auniter.ini`, and finally `$HOME/.auniter.ini`.
     * Add `config` command to print the auto-detected `auniter.ini` file.
+    * Add `compile` command as an alias for `verify`, because the Arduino-CLI
+      binary uses `compile` instead of `verify`.
     * Add support for [arduino-cli](https://github.com/arduino/arduino-cli)
       using the `AUNITER_ARDUINO_CLI` environment variable. The `preprocessor`
       directive in the `auniter.ini` must not contain a string due to a bug in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
     * Add `config` command to print the auto-detected `auniter.ini` file.
     * Add `compile` command as an alias for `verify`, because the Arduino-CLI
       binary uses `compile` instead of `verify`.
+    * Add `mon` command as an alias for `monitor`, because we often want
+      to run the 'monitor' command after an 'upmon', and this makes it
+      easier to retrieve the previous 'upmon' command from the bash history and
+      just remove the 'up'.
     * Add support for [arduino-cli](https://github.com/arduino/arduino-cli)
       using the `AUNITER_ARDUINO_CLI` environment variable. The `preprocessor`
       directive in the `auniter.ini` must not contain a string due to a bug in

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ configurations and aliases which look like this:
 
 ## Installation
 
-1. See [AUniter tools](tools/) to install the `auniter.sh` command line tools.
+1. See [AUniter Tools](tools/) to install the `auniter.sh` command line tools.
 1. See [AUniter Jenkins Integration](jenkins/) to integrate with Jenkins.
 1. See [AUniter Badge Service](BadgeService/) to display the
    build status in the source repository.
@@ -144,7 +144,7 @@ configurations and aliases which look like this:
     * Arduino IDE
         * tested on 1.8.5, 1.8.6, 1.8.7, 1.8.9, 1.8.13
 * **AUniter Jenkins Integration** requires the following:
-    * **Auniter Tools**
+    * **AUniter Tools**
     * [AUnit](https://github.com/bxparks/AUnit) (optional)
     * [Jenkins](https://jenkins.io) Continuous Integration platform
     * Linux system (tested on Ubuntu 16.04, 17.10, 18.04)
@@ -220,6 +220,17 @@ There are a few features of `amake` that I found problemmatic for my purposes.
   validate multiple `*.ino` files, on multiple Arduino boards, on multiple
   serial ports.
 
+### Arduino-CLI
+
+The [Arduino CLI](https://github.com/arduino/arduino-cli) is currently in alpha
+stage. I did not learn about it until I had built the `AUniter` tools. It is a
+Go Lang program which interacts relatively nicely with the Arduino IDE.
+
+Version 1.8 includes an initial integration with Arduino-CLI and exposes
+that functionality through the `--cli` flag. However, the Arduino-CLI has a
+broken parser for its `--build-properties` flag, so it does not support `-D`
+flags that contain strings.
+
 ### Arduino-Makefile
 
 The [Arduino-Makefile](https://github.com/sudar/Arduino-Makefile) package
@@ -290,17 +301,6 @@ The [Arduino Builde](https://github.com/arduino/arduino-builder) seems to be a
 collection of Go-lang programs that provide commandline interface for compiling
 Arduino sketches. However, I have not been able to find any documentation that
 describes how to actually to use these programs.
-
-### Arduino-CLI
-
-The [Arduino CLI](https://github.com/arduino/arduino-cli) is currently in alpha
-stage. I did not learn about it until I had built the `AUniter` tools. It is a
-Go Lang program which interacts relatively nicely with the Arduino IDE.
-
-Version 1.8 includes an initial integration with Arduino-CLI and exposes
-that functionality through the `--cli` flag. However, the Arduino-CLI has a
-broken parser for its `--build-properties` flag, so it does not support `-D`
-flags that contain strings.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -28,14 +28,13 @@ through the Arduino IDE binary in command line mode.
 
 There are 3 components to the **AUniter** package:
 
-1. A command line tool (`tools/auniter.sh`) that can compile and upload Arduino
-   programs. It can also upload unit tests written in
+1. A command line tool [`tools/auniter.sh`](tools/) that can compile and upload
+   Arduino programs. It can also upload unit tests written in
    [AUnit](https://github.com/bxparks/AUnit) and validate the success and
    failure of the unit tests.
-1. Integration of the `auniter.sh` script with a locally hosted Jenkins system
-   (`jenkins/`) to provide continuous build and test integration upon changes
-   to the source code repository.
-    * This depends on the `auniter.sh` above.
+1. A locally hosted [Jenkins Integration](jenkins/) to provide Ccontinuous
+   Integration (CI) of unit tests upon changes to the source code repository.
+    * This depends on the `auniter.sh` described above.
     * As of v1.8 or so, I no longer use this integration because:
         1. the Arduino IDE is simply too slow, with some of my projects taking
             1-2 hours to run through all the test suites,
@@ -47,12 +46,12 @@ There are 3 components to the **AUniter** package:
       [UnixHostDuino](https://github.com/bxparks/UnixHostDuino) project
       more frequently as an alternative, even though it cannot handle the
       Arduino programs that depend on specific hardware.
-1. A badge service (`BadgeService/`) running on
+1. A [Badge Service](BadgeService/) running on
    [Google Cloud Functions](https://cloud.google.com/functions/)
    that allows the locally hosted Jenkins system to update the status of the
    build, so that an indicator badge can be displayed on a source control
    repository like GitHub.
-    * This depends on the Jenkins service above.
+    * This depends on the Jenkins Integration described above.
     * As of v1.8 or so, I no longer use this service, because the Arduino IDE
       is too slow to handle the number of INO files that I needed to compile in
       my Continuous Integration pipeline. I may revisit this when Arduino-CLI
@@ -134,7 +133,7 @@ configurations and aliases which look like this:
 
 ## System Requirements
 
-* AUniter Tools require the following:
+* **AUniter Tools** require the following:
     * Linux
         * tested on Ubuntu 16.04, 17.10, 18.04, 20.04
     * MacOS
@@ -144,13 +143,14 @@ configurations and aliases which look like this:
         * requires GNU gsed
     * Arduino IDE
         * tested on 1.8.5, 1.8.6, 1.8.7, 1.8.9, 1.8.13
-* AUniter Integration with Jenkins requires the following:
-    * `auniter.sh`
+* **AUniter Jenkins Integration** requires the following:
+    * **Auniter Tools**
     * [AUnit](https://github.com/bxparks/AUnit) (optional)
     * [Jenkins](https://jenkins.io) Continuous Integration platform
     * Linux system (tested on Ubuntu 16.04, 17.10, 18.04)
-* AUniter BadgeService requires the following:
-    * AUniter Integration with Jenkins
+* **AUniter BadgeService** requires the following:
+    * **AUniter Integration with Jenkins**
+    * [Google Cloud Services](https://cloud.google.com/) account
     * [Google Functions](https://cloud.google.com/functions/)
 
 Windows is definitely not supported because the scripts require the `bash`

--- a/README.md
+++ b/README.md
@@ -35,14 +35,28 @@ There are 3 components to the **AUniter** package:
 1. Integration of the `auniter.sh` script with a locally hosted Jenkins system
    (`jenkins/`) to provide continuous build and test integration upon changes
    to the source code repository.
+    * This depends on the `auniter.sh` above.
+    * As of v1.8 or so, I no longer use this integration because:
+        1. the Arduino IDE is simply too slow, with some of my projects taking
+            1-2 hours to run through all the test suites,
+        1. The Arduino-CLI tool cannot replace the Arduino IDE because its
+            [broken --build-properties
+            flag](https://github.com/arduino/arduino-cli/issues/846), and,
+        1. The Jenkins service is too brittle and cumbersome to maintain.
+    * I have started to use the
+      [UnixHostDuino](https://github.com/bxparks/UnixHostDuino) project
+      more frequently as an alternative, even though it cannot handle the
+      Arduino programs that depend on specific hardware.
 1. A badge service (`BadgeService/`) running on
    [Google Cloud Functions](https://cloud.google.com/functions/)
    that allows the locally hosted Jenkins system to update the status of the
    build, so that an indicator badge can be displayed on a source control
    repository like GitHub.
-
-(These components are organized as onion rings. In other words, each component
-in this list requires the previous component to function.)
+    * This depends on the Jenkins service above.
+    * As of v1.8 or so, I no longer use this service, because the Arduino IDE
+      is too slow to handle the number of INO files that I needed to compile in
+      my Continuous Integration pipeline. I may revisit this when Arduino-CLI
+      fixes the broken parser of its `--build-properties` flag.
 
 The `auniter.sh` script uses the command line mode of the
 [Arduino IDE binary](https://github.com/arduino/Arduino/blob/master/build/shared/manpage.adoc).
@@ -107,9 +121,9 @@ configurations and aliases which look like this:
   preprocessor = -DAUNITER_MICRO -DAUNITER_BUTTON=3
 ```
 
-Version: 1.7.2 (2020-08-21)
+**Version**: 1.8 (2020-09-04)
 
-Changelog: [CHANGELOG.md](CHANGELOG.md)
+**Changelog**: [CHANGELOG.md](CHANGELOG.md)
 
 ## Installation
 
@@ -121,18 +135,23 @@ Changelog: [CHANGELOG.md](CHANGELOG.md)
 ## System Requirements
 
 * AUniter Tools require the following:
-    * Linux system (tested on Ubuntu 16.04, 17.10, 18.04, 20.04)
-    * Arduino IDE (tested on 1.8.5, 1.8.6, 1.8.7, 1.8.9, 1.8.13)
+    * Linux
+        * tested on Ubuntu 16.04, 17.10, 18.04, 20.04
+    * MacOS
+        * tested on 10.14.6 (Mojave)
+        * *not* tested on 10.15 (Catalina)
+        * requires GNU coreutils
+        * requires GNU gsed
+    * Arduino IDE
+        * tested on 1.8.5, 1.8.6, 1.8.7, 1.8.9, 1.8.13
 * AUniter Integration with Jenkins requires the following:
-    * AUniter Tools
+    * `auniter.sh`
     * [AUnit](https://github.com/bxparks/AUnit) (optional)
     * [Jenkins](https://jenkins.io) Continuous Integration platform
     * Linux system (tested on Ubuntu 16.04, 17.10, 18.04)
 * AUniter BadgeService requires the following:
     * AUniter Integration with Jenkins
     * [Google Functions](https://cloud.google.com/functions/)
-
-Some exploration on MacOS has been done, but it is currently not supported.
 
 Windows is definitely not supported because the scripts require the `bash`
 shell. I am not familiar with
@@ -143,6 +162,8 @@ so I do not know if it would work on that.
 
 * [Teensyduino](https://pjrc.com/teensy/teensyduino.html) is not supported
   due to [Issue #4](https://github.com/bxparks/AUniter/issues/4).
+* Arduino-CLI has a broken parser for its `--build-properties` flag, so
+  `-D` flags with a string does not work.
 
 ## Alternatives Considered
 
@@ -275,11 +296,11 @@ describes how to actually to use these programs.
 The [Arduino CLI](https://github.com/arduino/arduino-cli) is currently in alpha
 stage. I did not learn about it until I had built the `AUniter` tools. It is a
 Go Lang program which interacts relatively nicely with the Arduino IDE.
-According to the developers, this project will eventually replace the command
-line mode of the
-[Arduino IDE binary](https://github.com/arduino/Arduino/blob/master/build/shared/manpage.adoc).
-When that happens, the `auniter.sh` script may use the `Arduino CLI` binary
-directly, instead of going through the Arduino IDE (in headless mode).
+
+Version 1.8 includes an initial integration with Arduino-CLI and exposes
+that functionality through the `--cli` flag. However, the Arduino-CLI has a
+broken parser for its `--build-properties` flag, so it does not support `-D`
+flags that contain strings.
 
 ## License
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,15 +1,18 @@
 # AUniter Command Line Tools
 
-The `auniter.sh` shell is a wrapper around the Arduino IDE using the [Arduino
-Commandline
+The `auniter.sh` script is a `bash` script wrapper around the Arduino IDE using
+the [Arduino Commandline
 Interface](https://github.com/arduino/Arduino/blob/master/build/shared/manpage.adoc).
-It has been extensively tested on Ubuntu Linux. It works on my MacOS laptop but
-testing is not as extensive.
+Starting with v1.8, the `auniter.sh` script also supports the
+[Arduino-CLI](https://github.com/arduino/arduino-cli) binary. It has been
+extensively tested on Ubuntu Linux 18.04 and 20.04. It works on my MacOS 10.14.6
+(Mojave) laptop but testing is not as extensive. I do not have a machine running
+MacOS 10.15 (Catalina).
 
 The `auniter.sh` script takes advantage of the command line interface to provide
 some useful extended functionality:
 
-1) Verifying (compile) multiple `*.ino` files across multiple boards.
+1) Verifying (compiling) multiple `*.ino` files across multiple boards.
 2) Uploading multiple `*.ino` files across multiple boards.
 3) Testing multiple [AUnit](https://github.com/bxparks/AUnit) unit tests
 across multiple boards.
@@ -38,6 +41,12 @@ AUnit unit test to determine if the test passed or failed.
 
 1. Install the [Arduino IDE](https://www.arduino.cc/en/Main/Software). The
 following versions have been tested: 1.8.5, 1.8.6, 1.8.7, 1.8.13.
+    * Make a note of where the `arduino/` directory is installed.
+    * I usually rename the directory to contain the version number, for example,
+      `mv arduino arduino-1.8.13`.
+1. Install the [arduino-cli](https://github.com/arduino/arduino-cli).
+    * Make a note of where you installed the `arduino-cli` binary.
+    * I normally install it in my `$HOME/bin` directory.
 1. Install Python3 if you don't already have it.
     * `$ apt install python3 python3-pip`
 1. Install various Python packages
@@ -54,13 +63,20 @@ following versions have been tested: 1.8.5, 1.8.6, 1.8.7, 1.8.13.
 
 ### MacOS (10.14.6 Mojave)
 
-Most of the functionality seems to work under MacOS (10.14 Mojave), but I have
+Most of the functionality seems to work under MacOS 10.14 (Mojave), but I have
 not tested things as much as Linux. I do not own a Mac that runs 10.15
-(Catalina), so I cannot test anything there.
+(Catalina), so I cannot test anything there. The script relies on the GNU
+versions of a few core Unix commands, instead of the BSD versions supplied on
+the MacOS by default. You need to install the GNU versions as described below.
 
+1. Install [Home Brew](https://brew.sh/)
 1. Install the [Arduino IDE](https://www.arduino.cc/en/Main/Software). The
    following versions have been tested: 1.8.13.
-1. Install [Home Brew](https://brew.sh/)
+    * Make a note of where you installed the app.
+1. Install the [arduino-cli](https://github.com/arduino/arduino-cli).
+    * Make a note of where you installed the `arduino-cli` binary.
+    * If you installed it using `brew`, it will be located at
+      `/usr/local/bin/arduino-cli`.
 1. Install various GNU shell utils:
     * `$ brew install coreutils`
     * `$ brew install gsed`
@@ -70,7 +86,7 @@ not tested things as much as Linux. I do not own a Mac that runs 10.15
 1. Install various Python packages.
     * [pyserial](https://pypi.org/project/pyserial/)
         * `$ pip3 install --user serial`
-1 Install a terminal program (for the `auniter monitor` functionality)
+1. Install a terminal program (for the `auniter monitor` functionality)
     * [picocom](https://linux.die.net/man/8/picocom)
         * tested with v3.1
         * `$ brew install picocom`
@@ -92,37 +108,47 @@ The latest development version can be installed by cloning the
 `develop` branch. The `master` branch contains the stable release. The
 `auniter.sh` script is in the `./tools` directory.
 
-### Environment Variable
+### Environment Variables
 
-The `AUNITER_ARDUINO_BINARY` environment variable **must** be defined in your
-`.bashrc` file. Locate the directory where the Arduino IDE has been installed.
-I normally install multiple versions of the Arduino IDE, so I will rename them
-to include the version number. For example, the latest Arduion IDE 1.8.13 is
-installed in the following directories:
+There are 2 environment variables that must be defined, depending on whether you
+use the `auniter.sh` script with the Arduino IDE or with arduino-cli:
 
-* Ubuntu Linux
-    * `$HOME/dev/arduino-1.8.13/`
-* MacOS
-    * `$HOME/dev/Arduino-1.8.13.app/`
+* `AUNITER_ARDUINO_BINARY` variable contains the location of the Arduino IDE
+  binary.
+* `AUNITER_ARDUINO_CLI` variable contains the location of the `arduino-cli`
+  binary.
 
-Then the `AUNITER_ARDUINO_BINARY` is the location of the actual Arduino IDE
-program, which are the following for me:
+At least one of these must be defined in your `$HOME/.bashrc` file.
 
-* Ubuntu Linux
-    * `export AUNITER_ARDUINO_BINARY="$HOME/dev/arduino-1.8.13/arduino"`
-* MacOS
-    * `export AUNITER_ARDUINO_BINARY="$HOME/dev/Arduino-1.8.13.app/Contents/MacOS/Arduino`
+**Ubuntu Linux**
 
-Save your `.bashrc` file, logout, and log back in (or manually set the
-environment variable in each of your terminal windows).
+The varibles will look something like this:
 
-### Shell Alias
+```
+export AUNITER_ARDUINO_BINARY="$HOME/dev/arduino-1.8.13/arduino"`
+export AUNITER_ARDUINO_CLI="$HOME/bin/arduino-cli"
+```
+
+(assuming that the Arduino IDE was installed into a directory called
+`arduino-1.8.13/`).
+
+**MacOS**
+
+The variables will look something like this:
+```
+export AUNITER_ARDUINO_BINARY="$HOME/dev/Arduino-1.8.13.app/Contents/MacOS/Arduino`
+export AUNITER_ARDUINO_CLI='/usr/local/bin/arduino-cli'
+```
+
+You may need to log out and log back in to activate these environment variables.
+
+### Shell Aliases
 
 I recommend creating an alias for the `auniter.sh` script in your `.bashrc`
 file. I use the following 2 aliases:
 ```
 alias auniter='{path-to-auniter-directory}/tools/auniter.sh'
-alias au='{path-to-auniter-directory}/tools/auniter.sh'
+alias au='auniter'
 ```
 Don't add `{path-to-auniter-directory}/tools` to your `$PATH`. It won't work
 because `auniter.sh` needs to know its own install directory to find helper
@@ -133,17 +159,23 @@ alias.)**
 
 ### Config File
 
-The `auniter.sh` script looks for a config file named `$HOME/.auniter.ini` in
-your home directory. The format of the file is the
-[INI file](https://en.wikipedia.org/wiki/INI_file),
-and the meaning of these properties will be explained below. This INI file has
-evolved to be similar to the one used by [PlatformIO](https://platformio.org/)
-with some major differences:
+The `auniter.sh` script looks for a config file named `auniter.ini` in
+your home directory. Starting with v1.8, the `auniter.ini` file is searched in
+the following order:
 
-1. The `auniter.ini` format is simpler and easier to use (but less flexible)
-1. There is only one `auniter.ini` per user (shared among many projects and
-  libraries), instead of one INI file per project as used by PlatformIO (The
-  most recent version of auniter.sh allows per-project `auniter.ini` file.)
+1. Use the value of --config flag if it is given, else,
+2. Look for 'auniter.ini' in the current directory, else,
+3. Look for 'auniter.ini' in any parent directory recursively until `/`, else,
+4. Look for '$HOME/auniter.ini', else,
+5. Look for '$HOME/.auniter.ini'.
+
+I typically use only a single `$HOME/.auniter.ini` file, but occasionally, it is
+useful to override the default with a project-specific `auniter.ini` file.
+
+The format of the file is the [INI
+file](https://en.wikipedia.org/wiki/INI_file), and the meaning of these
+properties will be explained below. The `auniter.ini` file has evolved to be
+similar to the one used by [PlatformIO](https://platformio.org/).
 
 For the purposes of this tutorial, copy the `sample.auniter.ini` file to
 `$HOME/.auniter.ini`. For reference, here's the condensed version of the sample
@@ -200,10 +232,12 @@ Type `auniter --help` to get the latest usage. Here is the summary portion
 of the help message:
 ```
 $ auniter --help
-Usage: auniter.sh [-h] [flags] command [flags] [args ...]
+Usage: auniter.sh [-h] [auniter_flags] command [command_flags] [args ...]
+       auniter.sh config
        auniter.sh envs
        auniter.sh ports
        auniter.sh verify {env} files ...
+       auniter.sh compile {env} files ...
        auniter.sh upload {env}:{port},... files ...
        auniter.sh test {env}:{port},... files ...
        auniter.sh monitor [{env}:]{port}
@@ -213,6 +247,37 @@ Usage: auniter.sh [-h] [flags] command [flags] [args ...]
 
 The 7 subcommands (`envs`, `ports`, `verify`, `upload`, `test`, `monitor`,
 `upmon`) are described below.
+
+### AUniter Flags
+
+There are several top-level flags:
+
+* `--ide`: Use the Arduino IDE and the `AUNITER_ARDUINO_BINARY` environment
+  variable. This is the default if neither `--ide` nor `--cli` are given.
+* `--cli`: Use the arduino-cli and the `AUNITER_ARDUINO_CLI` environment
+  variable
+* `--verbose`: Print out verbose debugging output
+
+If you want to make `--cli` the default, create the `auniter` alias with this
+flag:
+
+```
+alias auniter='.../tools/auniter.sh --cli'
+alias au=auniter
+```
+
+### Subcommand: config
+
+The `config` command shows the location of the current `auniter.ini` config
+file, and then prints out the content of that file.
+
+```
+$ auniter config
+Reading config: /home/brian/.auniter.ini
+Using IDE: AUNITER_ARDUINO_BINARY=/home/brian/dev/arduino-1.8.13/arduino
++ cat /home/brian/.auniter.ini
+[...]
+```
 
 ### Subcommand: envs
 
@@ -253,12 +318,13 @@ $ auniter ports
 /dev/cu.usbserial-1410 - USB2.0-Serial
 ```
 
-### Subcommand: verify
+### Subcommand: verify and compile
 
-This command runs the Arduino IDE binary and verifies that the given program
-files build successfully for the specified environment `{env}` which is
-defined in the `.auniter.ini` file. The following example verifies that the
-`Blink.ino` sketch compiles under the `nano` environment:
+The `verify` and `compile` commands are aliases of each other. This command runs
+the Arduino IDE binary and verifies that the given program files build
+successfully for the specified environment `{env}` which is defined in the
+`.auniter.ini` file. The following example verifies that the `Blink.ino` sketch
+compiles under the `nano` environment:
 
 ```
 $ auniter verify uno Blink.ino

--- a/tools/README.md
+++ b/tools/README.md
@@ -770,6 +770,15 @@ In all the other `*.cpp` and `*.h` files, you would just do:
 
 ## Limitations
 
-[Teensyduino](https://pjrc.com/teensy/teensyduino.html) is not
-currently supported because of
+* [Teensyduino](https://pjrc.com/teensy/teensyduino.html) is not
+  currently supported because of
 [Issue #4](https://github.com/bxparks/AUniter/issues/4).
+* When using the Arduino-CLI (through the `--cli` flag), the `preprocessor`
+  flags are passed into the `arduino-cli` binary using the `--build-properties`
+  flag. Unfortunately, the Arduino-CLI has a broken parser for that flag (see
+  https://github.com/arduino/arduino-cli/issues/846), so any `-D` flag that
+  contains a string (double-quotes) will not be processed correctly. The
+  `auniter.sh` script detects this condition and exits with an error message if
+  a `-D` flag with a string is detected. The only solution right now is to use
+  the Arduino IDE (using the `--ide` option) instead of the Arduino-CLI (using
+  the `--cli` option).

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,14 +1,13 @@
 # AUniter Command Line Tools
 
-These are the command line tools for compiling Arduino sketches, uploading them
-to microcontroller boards, and validating unit tests written in
-[AUnit](https://github.com/bxparks/AUnit).
+The `auniter.sh` shell is a wrapper around the Arduino IDE using the [Arduino
+Commandline
+Interface](https://github.com/arduino/Arduino/blob/master/build/shared/manpage.adoc).
+It has been extensively tested on Ubuntu Linux. It works on my MacOS laptop but
+testing is not as extensive.
 
-## Summary
-
-The `auniter.sh` shell is a wrapper around the
-[Arduino Commandline Interface](https://github.com/arduino/Arduino/blob/master/build/shared/manpage.adoc)
-that supports the following functionality:
+The `auniter.sh` script takes advantage of the command line interface to provide
+some useful extended functionality:
 
 1) Verifying (compile) multiple `*.ino` files across multiple boards.
 2) Uploading multiple `*.ino` files across multiple boards.
@@ -23,11 +22,11 @@ started when changes to the git repository are detected, and unit tests can be
 executed on Arduino boards attached to the serial port of the local machine. The
 Jenkins dashboard can display the status of builds and tests.
 
-The `auniter.sh` script uses the `$HOME/.auniter.ini` config file to
-define named *environments* that correspond to specific hardware devices.
-The environment `NAME` is used to control the target build flags and options.
-The config file also allow mapping of a short alias (e.g. `uno`) to the fully
-qualified board name (`fqbn`) used by the arduino binary (e.g.
+The `auniter.sh` script uses the a config file (often located at
+`$HOME/.auniter.ini`) to define named *environments* that correspond to specific
+hardware devices. The environment name takes the form `env:{name}` (e.g.
+`env:nano`). The config file also allow mapping of a short alias (e.g. `uno`) to
+the fully qualified board name (`fqbn`) used by the arduino binary (e.g.
 `arduino:avr:uno`).
 
 The script can monitor the output of the serial port, and parse the output of an
@@ -35,39 +34,58 @@ AUnit unit test to determine if the test passed or failed.
 
 ## Installation
 
-### Requirements
+### Ubuntu Linux (18.04, 20.04)
 
-These scripts are meant to be used from a Linux environment. The following
-components and version numbers have been tested:
-
-* Ubuntu Linux
-    * Ubuntu 16.04
-    * Ubuntu 17.10
-    * Ubuntu 18.04
-    * Xubuntu 18.04
-* [Arduino IDE](https://arduino.cc/en/Main/Software):
-    * 1.8.5
-    * 1.8.6
-    * 1.8.7
-* [pyserial](https://pypi.org/project/pyserial/)
-    * 3.4-1
-    * installation: `sudo apt install python3 python3-pip python3-serial`
-* terminal program (for `auniter monitor` functionality)
+1. Install the [Arduino IDE](https://www.arduino.cc/en/Main/Software). The
+following versions have been tested: 1.8.5, 1.8.6, 1.8.7, 1.8.13.
+1. Install Python3 if you don't already have it.
+    * `$ apt install python3 python3-pip`
+1. Install various Python packages
+    * [pyserial](https://pypi.org/project/pyserial/)
+        * `$ pip3 install --user serial`
+1 Install a terminal program (for the `auniter monitor` functionality). I use
+`picocom` but `microcom` seems to work pretty well:
     * [picocom](https://linux.die.net/man/8/picocom)
-        * tested with v2.2
-        * installation: `sudo apt install picocom`
+        * tested with v2.2, v3.1
+        * `$ sudo apt install picocom`
     * [microcom](http://manpages.ubuntu.com/manpages/bionic/man1/microcom.1.html).
         * tested with v2016.01.0
-        * installation: `sudo apt install microcom`
+        * `$ sudo apt install microcom`
 
-Some limited testing on MacOS has been done, but it is currently not supported.
+### MacOS (10.14.6 Mojave)
+
+Most of the functionality seems to work under MacOS (10.14 Mojave), but I have
+not tested things as much as Linux. I do not own a Mac that runs 10.15
+(Catalina), so I cannot test anything there.
+
+1. Install the [Arduino IDE](https://www.arduino.cc/en/Main/Software). The
+   following versions have been tested: 1.8.13.
+1. Install [Home Brew](https://brew.sh/)
+1. Install various GNU shell utils:
+    * `$ brew install coreutils`
+    * `$ brew install gsed`
+1. Install Python3. I have tested with Python3.8 but Python3.7 should also work.
+    * `$ brew install python3.8`
+    * I think the `pip3` is automatically installed by`python3.8`.
+1. Install various Python packages.
+    * [pyserial](https://pypi.org/project/pyserial/)
+        * `$ pip3 install --user serial`
+1 Install a terminal program (for the `auniter monitor` functionality)
+    * [picocom](https://linux.die.net/man/8/picocom)
+        * tested with v3.1
+        * `$ brew install picocom`
+
+### Windows
 
 Windows is definitely not supported because the scripts require the `bash`
-shell. I am not familiar with
+shell. It *might* be possible to use this under
 [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10)
-so I do not know if it would work on that.
+but I do not know.
 
-### Obtain the Code
+### Obtain the AUniter Code
+
+This is not an Arduino library. You will not find it in the Arduino Library
+manager. You need to grab the code direclty from GitHub.
 
 The latest development version can be installed by cloning the
 [GitHub repository](https://github.com/bxparks/AUniter), and checking out the
@@ -76,16 +94,27 @@ The latest development version can be installed by cloning the
 
 ### Environment Variable
 
-There is one environment variable that **must** be defined in your `.bashrc`
-file:
+The `AUNITER_ARDUINO_BINARY` environment variable **must** be defined in your
+`.bashrc` file. Locate the directory where the Arduino IDE has been installed.
+I normally install multiple versions of the Arduino IDE, so I will rename them
+to include the version number. For example, the latest Arduion IDE 1.8.13 is
+installed in the following directories:
 
-* `export AUNITER_ARDUINO_BINARY={path}` - location of the Arduino command line
-  binary
+* Ubuntu Linux
+    * `$HOME/dev/arduino-1.8.13/`
+* MacOS
+    * `$HOME/dev/Arduino-1.8.13.app/`
 
-I have something like this in my `$HOME/.bashrc` file:
-```
-export AUNITER_ARDUINO_BINARY="$HOME/dev/arduino-1.8.5/arduino"
-```
+Then the `AUNITER_ARDUINO_BINARY` is the location of the actual Arduino IDE
+program, which are the following for me:
+
+* Ubuntu Linux
+    * `export AUNITER_ARDUINO_BINARY="$HOME/dev/arduino-1.8.13/arduino"`
+* MacOS
+    * `export AUNITER_ARDUINO_BINARY="$HOME/dev/Arduino-1.8.13.app/Contents/MacOS/Arduino`
+
+Save your `.bashrc` file, logout, and log back in (or manually set the
+environment variable in each of your terminal windows).
 
 ### Shell Alias
 
@@ -110,13 +139,16 @@ your home directory. The format of the file is the
 and the meaning of these properties will be explained below. This INI file has
 evolved to be similar to the one used by [PlatformIO](https://platformio.org/)
 with some major differences:
-1. `auniter.ini` is far simpler and easier to use (but less flexible)
-1. there is only one `auniter.ini` per user (shared among many projects and
-  libraries), instead of one INI file per project as used by PlatformIO
+
+1. The `auniter.ini` format is simpler and easier to use (but less flexible)
+1. There is only one `auniter.ini` per user (shared among many projects and
+  libraries), instead of one INI file per project as used by PlatformIO (The
+  most recent version of auniter.sh allows per-project `auniter.ini` file.)
 
 For the purposes of this tutorial, copy the `sample.auniter.ini` file to
 `$HOME/.auniter.ini`. For reference, here's the condensed version of the sample
 with comments stripped out:
+
 ```ini
 [auniter]
   monitor = picocom -b $baud --omap crlf --imap lfcrlf --echo $port
@@ -198,7 +230,10 @@ esp32
 
 ### Subcommand: ports
 
-The `ports` command simply lists the available serial ports:
+The `ports` command simply lists the available serial ports.
+
+On Ubuntu, it looks something like this:
+
 ```
 $ auniter ports
 /dev/ttyS4 - n/a
@@ -208,6 +243,14 @@ $ auniter ports
 /dev/ttyUSB0 - USB2.0-Serial
 /dev/ttyACM1 - USB Serial
 /dev/ttyACM0 - SparkFun Pro Micro
+```
+
+On MacOS, it looks like this:
+```
+$ auniter ports
+/dev/cu.Bluetooth-Incoming-Port - n/a
+/dev/cu.wchusbserial1410 - USB2.0-Serial
+/dev/cu.usbserial-1410 - USB2.0-Serial
 ```
 
 ### Subcommand: verify
@@ -250,12 +293,16 @@ $ auniter upload uno:USB0 Blink.ino
 $ auniter upload micro:/dev/ttyACM0 Blink.ino Clock.ino
 ```
 
-### Port Specifier {port}
+### Port Specifier {port} Shorthand
 
 The serial port on a Linux machine is a file that has the form `/dev/ttyXXXn`,
 for example `/dev/ttyUSB0`. For convenience, the repetitive `/dev/tty` part can
 be omitted from the `{port}` specifier. In other words, you can type
 `uno:USB0`, instead of `uno:/dev/ttyUSB0`.
+
+On the MacOS, the serial port seems to look like `/dev/cu.wchusbserial1410`. A
+shorthand is *not* supported on the Mac so the full device path must be
+provided.
 
 ### Subcommand: test
 
@@ -353,7 +400,7 @@ There are 4 parameters currently supported in an environment section:
 [env:NAME]
   board = {alias}
   locking = (true | false)
-  exclude = egrep regular expression
+  exclude = egrep regular expression separaed by '|' symbol
   preprocessor = space-separated list of preprocessor symbols
 ```
 
@@ -466,6 +513,9 @@ environment, set the `locking` parameter to `false`, like this:
   board = promicro16
   locking = false
 ```
+
+Unfortunately, the MacOS does not support the `flock` command, so locking is
+disabled on the Mac.
 
 ### Excluding Files (exclude)
 
@@ -655,4 +705,5 @@ In all the other `*.cpp` and `*.h` files, you would just do:
 ## Limitations
 
 [Teensyduino](https://pjrc.com/teensy/teensyduino.html) is not
-currently supported because of Issue #4.
+currently supported because of
+[Issue #4](https://github.com/bxparks/AUniter/issues/4).

--- a/tools/README.md
+++ b/tools/README.md
@@ -241,6 +241,7 @@ Usage: auniter.sh [-h] [auniter_flags] command [command_flags] [args ...]
        auniter.sh upload {env}:{port},... files ...
        auniter.sh test {env}:{port},... files ...
        auniter.sh monitor [{env}:]{port}
+       auniter.sh mon [{env}:]{port}
        auniter.sh upmon {env}:{port} file
 [...]
 ```

--- a/tools/auniter.sh
+++ b/tools/auniter.sh
@@ -342,7 +342,7 @@ function process_file() {
             $preserve \
             --summary_file $summary_file \
             $file
-    else
+    else # $mode == 'test' | 'upload'
         # flock(1) returns status 1 if the lock file doesn't exist, which
         # prevents distinguishing that from failure of run_arduino.sh.
         if [[ ! -e $port ]]; then

--- a/tools/auniter.sh
+++ b/tools/auniter.sh
@@ -63,6 +63,7 @@ Usage: auniter.sh [-h] [auniter_flags] command [command_flags] [args ...]
        auniter.sh upload {env}:{port},... files ...
        auniter.sh test {env}:{port},... files ...
        auniter.sh monitor [{env}:]{port}
+       auniter.sh mon [{env}:]{port}
        auniter.sh upmon {env}:{port} file
 END
 }
@@ -96,6 +97,7 @@ Commands (command):
     upload  Upload the sketch(es) to the given board at port.
     test    Upload the AUnit unit test(s), and verify pass or fail.
     monitor Run the serial terminal defined in aniter.conf on the given port.
+    mon     Alias for 'monitor'.
     upmon   Upload the sketch and run the monitor upon success.
 
 Command Flags (command_flags):
@@ -678,7 +680,7 @@ function main() {
         compile) mode='verify'; handle_build "$@" ;;
         upload) handle_build "$@" ;;
         test) handle_build "$@" ;;
-        monitor) handle_monitor "$@" ;;
+        monitor|mon) handle_monitor "$@" ;;
         upmon) handle_upmon "$@" ;;
         *) echo "Unknown command '$mode'"; usage ;;
     esac

--- a/tools/auniter.sh
+++ b/tools/auniter.sh
@@ -29,6 +29,7 @@ FLOCK_TIMEOUT_CODE=10
 function usage_common() {
     cat <<'END'
 Usage: auniter.sh [-h] [flags] command [flags] [args ...]
+       auniter.sh config
        auniter.sh envs
        auniter.sh ports
        auniter.sh verify {env} files ...
@@ -50,6 +51,7 @@ function usage_long() {
     cat <<'END'
 
 Commands:
+    config  Print location of the auto-detected config file.
     envs    List the environments defined in the CONFIG_FILE.
     ports   List the tty ports and the associated Arduino boards.
     verify  Verify the compile of the sketch file(s).
@@ -554,6 +556,12 @@ function read_default_configs() {
     port_timeout=${port_timeout_value:-$PORT_TIMEOUT}
 }
 
+# Print the current config file
+function print_config() {
+    local config_file="$1"
+    echo "$config_file"
+}
+
 # Parse auniter command line flags
 function main() {
     mode=
@@ -594,6 +602,7 @@ function main() {
     check_environment_variables
     create_temp_files
     case $mode in
+        config) print_config $config_file;;
         envs) list_envs $config_file;;
         ports) list_ports ;;
         verify) handle_build "$@" ;;

--- a/tools/auniter.sh
+++ b/tools/auniter.sh
@@ -32,7 +32,7 @@ Usage: auniter.sh [-h] [flags] command [flags] [args ...]
        auniter.sh config
        auniter.sh envs
        auniter.sh ports
-       auniter.sh verify {env} files ...
+       auniter.sh verify|compile {env} files ...
        auniter.sh upload {env}:{port},... files ...
        auniter.sh test {env}:{port},... files ...
        auniter.sh monitor [{env}:]{port}
@@ -55,6 +55,7 @@ Commands:
     envs    List the environments defined in the CONFIG_FILE.
     ports   List the tty ports and the associated Arduino boards.
     verify  Verify the compile of the sketch file(s).
+    compile Alias for 'verify'.
     upload  Upload the sketch(es) to the given board at port.
     test    Upload the AUnit unit test(s), and verify pass or fail.
     monitor Run the serial terminal defined in aniter.conf on the given port.
@@ -329,7 +330,7 @@ function process_file() {
     local file=$1
     echo "-------- Processing file '$file'"
 
-    if [[ "$mode" == 'verify' ]]; then
+    if [[ "$mode" == 'verify' || "$mode" == 'compile' ]]; then
         # Allow multiple verify commands to run at the same time.
         $DIRNAME/run_arduino.sh \
             --verify \
@@ -605,7 +606,7 @@ function main() {
         config) print_config $config_file;;
         envs) list_envs $config_file;;
         ports) list_ports ;;
-        verify) handle_build "$@" ;;
+        verify|compile) handle_build "$@" ;;
         upload) handle_build "$@" ;;
         test) handle_build "$@" ;;
         monitor) handle_monitor "$@" ;;

--- a/tools/auniter.sh
+++ b/tools/auniter.sh
@@ -85,8 +85,7 @@ AUniter Flags (auniter_flags):
     --cli|-c        Use the Arduino-CLI binary (arduino-cli) defined by
                     $AUNITER_ARDUINO_CLI.
     --verbose       Verbose output from various subcommands.
-    --preserve-temp-files
-                    Preserve /tmp/arduino* files for further analysis.
+    --preserve      Preserve /tmp/arduino* files for further analysis.
 
 Commands (command):
     config  Print location of the auto-detected config file.
@@ -146,7 +145,7 @@ function get_ino_file() {
 
 # Find the auniter.ini file, in the following order:
 # 1) Return the value of --config flag given as an argument, else
-# 2) Look for 'auniter.ini' in the current directoyr, else
+# 2) Look for 'auniter.ini' in the current directory, else
 # 3) Look for 'auniter.ini' in parent directories, else
 # 4) Look for '$HOME/auniter.ini', else
 # 5) Look for '$HOME/.auniter.ini'.
@@ -476,7 +475,7 @@ is not executable"
             exit 1
         fi
         if [[ ! -x $AUNITER_ARDUINO_CLI ]]; then
-            echo "AUNITER_ARDUINO_CLI=$AUNITER_ARDUINO_BINARY is not executable"
+            echo "AUNITER_ARDUINO_CLI=$AUNITER_ARDUINO_CLI is not executable"
             exit 1
         fi
 
@@ -625,7 +624,8 @@ function read_default_configs() {
 # Print the current config file
 function print_config() {
     local config_file="$1"
-    echo "$config_file"
+    echo "+ cat $config_file"
+    cat "$config_file"
 }
 
 # Parse auniter command line flags
@@ -639,12 +639,7 @@ function main() {
         case $1 in
             --help|-h) usage_long ;;
             --config) shift; config=$1 ;;
-            --cli|-c)
-                cli_option='cli'
-                # Give up on --build-properties, cannot get it to work.
-                # echo "Arduino-CLI cannot be supported due to broken --build-properties flag"
-                # exit 1
-                ;;
+            --cli|-c) cli_option='cli' ;;
             --ide|-i) cli_option='ide' ;;
             --verbose) verbose='--verbose' ;;
             --preserve) preserve='--preserve-temp-files' ;;

--- a/tools/auniter.sh
+++ b/tools/auniter.sh
@@ -80,9 +80,9 @@ function usage_long() {
 AUniter Flags (auniter_flags):
     --help          Print this help page.
     --config {file} Read configs from 'file' instead of $HOME/.auniter.conf'.
-    --ide|-i        Use the Arduino IDE binary (arduino or Arduino) defined
+    --ide           Use the Arduino IDE binary (arduino or Arduino) defined
                     by $AUNITER_ARDUINO_BINARY.
-    --cli|-c        Use the Arduino-CLI binary (arduino-cli) defined by
+    --cli           Use the Arduino-CLI binary (arduino-cli) defined by
                     $AUNITER_ARDUINO_CLI.
     --verbose       Verbose output from various subcommands.
     --preserve      Preserve /tmp/arduino* files for further analysis.
@@ -639,8 +639,8 @@ function main() {
         case $1 in
             --help|-h) usage_long ;;
             --config) shift; config=$1 ;;
-            --cli|-c) cli_option='cli' ;;
-            --ide|-i) cli_option='ide' ;;
+            --cli) cli_option='cli' ;;
+            --ide) cli_option='ide' ;;
             --verbose) verbose='--verbose' ;;
             --preserve) preserve='--preserve-temp-files' ;;
             -*) echo "Unknown auniter option '$1'"; usage ;;

--- a/tools/auniter.sh
+++ b/tools/auniter.sh
@@ -9,7 +9,7 @@
 #   * ./serial_monitor.py
 #   * Python3 (3.7 or 3.8 should work)
 #       * $ sudo apt install python3 python3-pip (Linux)
-#       * $ brew install python3
+#       * $ brew install python3 (MacOS)
 #   * Python serial
 #       * $ pip3 install --user serial
 #   * picocom

--- a/tools/run_arduino.sh
+++ b/tools/run_arduino.sh
@@ -188,7 +188,7 @@ if [[ "$AUNITER_ARDUINO_BINARY" =~ arduino-cli ]]; then
     if [[ $mode == 'upload' || $mode == 'test' ]]; then
         verify_or_upload_using_cli upload $1
     fi
-elif [[ "$AUNITER_ARDUINO_BINARY" =~ arduino ]]; then
+elif [[ "$AUNITER_ARDUINO_BINARY" =~ [aA]rduino ]]; then
     verify_or_upload_using_ide $mode $1
 else
     echo "Unsupported \$AUNITER_ARDUINO_BINARY: $AUNITER_ARDUINO_BINARY"

--- a/tools/run_arduino.sh
+++ b/tools/run_arduino.sh
@@ -25,7 +25,7 @@ Flags:
     --upload        Compile and upload the given program.
     --test          Verify the AUnit test after uploading the program.
     --env {env}     Name of the current build environment, for error messages.
-    --board {fqbn} Fully qualified board specifier.
+    --board {fqbn}  Fully qualified board name (fqbn).
     --port {port}   Serial port device (e.g. /dev/ttyUSB0).
     --baud {baud}   Speed of the serial port.
     --sketchbook {path}

--- a/tools/run_arduino.sh
+++ b/tools/run_arduino.sh
@@ -129,13 +129,12 @@ $port_flag \
 --build-properties $build_properties_value \
 $full_path"
 
-    # Unfortunately, arduino-cli is thoroughly broken with respons to the
+    # Unfortunately, arduino-cli is thoroughly broken with respect to the
     # parsing of the --build-properties flag if the value contains embedded
     # quotes, which happens if the -D symbol defines a c-string (in quotes).
     # I've tried every combination of escaping and backslashes in
-    # $build_properties_value, cannot get this to work.
-    echo "Arduino-CLI cannot be support due to broken --build-properties"
-    exit 1
+    # $build_properties_value, cannot get this to work. The 'auniter.sh' will
+    # detect this condition and fail immediately before this script is called.
     if ! $AUNITER_ARDUINO_CLI \
 $verbose \
 $arduino_cmd_mode \


### PR DESCRIPTION
* 1.8 (2020-09-04)
    * Auto-detect the location of 'auniter.ini' in the following order:
      `--config` flag, the current directory, any parent directory,
      `$HOME/auniter.ini`, and finally `$HOME/.auniter.ini`.
    * Add `config` command to print the auto-detected `auniter.ini` file.
    * Add `compile` command as an alias for `verify`, because the Arduino-CLI
      binary uses `compile` instead of `verify`.
    * Add `mon` command as an alias for `monitor`, because we often want
      to run the 'monitor' command after an 'upmon', and this makes it
      easier to retrieve the previous 'upmon' command from the bash history and
      just remove the 'up'.
    * Add support for [arduino-cli](https://github.com/arduino/arduino-cli)
      using the `AUNITER_ARDUINO_CLI` environment variable. The `preprocessor`
      directive in the `auniter.ini` must not contain a string due to a bug in
      `arduino-cli`.
    * Add better support and testing on MacOS 10.14 (Mojave).
