### PR TITLE
merge 1.9 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
     * Add `-D MACRO=value` flag which adds additional C-Preprocessor macros
       when using `verify`, `upload`, `upmon` and `test` subcommands. Multiple
       `-D` flags will define multiple MACROs.
+    * Add `--output filename` flag (short form `-o`) to the `upmon` command. It
+      captures the serial output of the microcontroller and saves it to the
+      given `filename`. By default, the process ends after a 10 second timeout.
+      However, if `--eof string` flag is given, the script looks for the given
+      string and terminates just after it is detected in the serial output. The
+      `string` itself is saved into the file. The `--output` flag could be
+      useful in the `monitor` command as well, but it is not clear that it would
+      be useful, so for the lack of infinite time, I have not implemented it.
 * 1.8 (2020-09-04)
     * Auto-detect the location of 'auniter.ini' in the following order:
       `--config` flag, the current directory, any parent directory,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 * Unreleased
+    * Add `-D MACRO=value` flag which adds additional C-Preprocessor macros
+      when using `verify`, `upload`, `upmon` and `test` subcommands. Multiple
+      `-D` flags will define multiple MACROs.
 * 1.8 (2020-09-04)
     * Auto-detect the location of 'auniter.ini' in the following order:
       `--config` flag, the current directory, any parent directory,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 * Unreleased
+* 1.9 (2020-12-03)
     * Add `-D MACRO=value` flag which adds additional C-Preprocessor macros
       when using `verify`, `upload`, `upmon` and `test` subcommands. Multiple
       `-D` flags will define multiple MACROs.

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ configurations and aliases which look like this:
   preprocessor = -DAUNITER_MICRO -DAUNITER_BUTTON=3
 ```
 
-**Version**: 1.8 (2020-09-04)
+**Version**: 1.9 (2020-12-03)
 
 **Changelog**: [CHANGELOG.md](CHANGELOG.md)
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -197,31 +197,31 @@ with comments stripped out:
 
 [env:uno]
   board = uno
-  preprocessor = -DAUNITER_UNO
+  preprocessor = -D AUNITER_UNO
 
 [env:nano]
   board = nano
-  preprocessor = -DAUNITER_NANO -DAUNITER_LEFT_BUTTON=2 -DAUNITER_RIGHT_BUTTON=3
+  preprocessor = -D AUNITER_NANO -D AUNITER_LEFT_BUTTON=2 -D AUNITER_RIGHT_BUTTON=3
 
 [env:leonardo]
   board = leonardo
   locking = false
-  preprocessor = -DAUNITER_LEONARDO
+  preprocessor = -D AUNITER_LEONARDO
 
 [env:micro]
   board = promicro16
   locking = false
-  preprocessor = -DAUNITER_MICRO
+  preprocessor = -D AUNITER_MICRO
 
 [env:esp8266]
   board = nodemcuv2
   exclude = AceButton/examples/CapacitiveButton
-  preprocessor = -DAUNITER_ESP8266 -DAUNITER_SSID="MyWiFi" -DAUNITER_PASSWORD="mypassword"
+  preprocessor = -D AUNITER_ESP8266 -D AUNITER_SSID="MyWiFi" -D AUNITER_PASSWORD="mypassword"
 
 [env:esp32]
   board = esp32
   exclude = AceButton/examples/CapacitiveButton
-  preprocessor = -DAUNITER_ESP32 -DAUNITER_SSID="MyWiFi" -DAUNITER_PASSWORD="mypassword"
+  preprocessor = -D AUNITER_ESP32 -D AUNITER_SSID="MyWiFi" -D AUNITER_PASSWORD="mypassword"
 ```
 
 The examples below will use these settings.
@@ -253,11 +253,18 @@ The 7 subcommands (`envs`, `ports`, `verify`, `upload`, `test`, `monitor`,
 
 There are several top-level flags:
 
-* `--ide`: Use the Arduino IDE and the `AUNITER_ARDUINO_BINARY` environment
-  variable. This is the default if neither `--ide` nor `--cli` are given.
-* `--cli`: Use the arduino-cli and the `AUNITER_ARDUINO_CLI` environment
-  variable
-* `--verbose`: Print out verbose debugging output
+* `--config path`
+    * Read the `auniter.ini` file from the given path, instead of using
+      the default `auniter.ini`.
+    * See the section *Config File* above for details on the search algorithm
+      used to find the default `auniter.ini` file.
+* `--ide`
+    * Use the Arduino IDE and the `AUNITER_ARDUINO_BINARY` environment
+    variable. This is the default if neither `--ide` nor `--cli` are given.
+* `--cli`
+    * Use the arduino-cli and the `AUNITER_ARDUINO_CLI` environment variable
+* `--verbose`
+    * Print out verbose debugging output
 
 If you want to make `--cli` the default, create the `auniter` alias with this
 flag:
@@ -611,13 +618,17 @@ By default, the `auniter.sh` script looks in the
 ```
 $HOME/.auniter.ini
 ```
-file in your home directory. The script can be told to look elsewhere using the
-`--config` command line flag. (Use `--config /dev/null` to indicate no config
-file.) This may be useful if the config file is checked into source control for
-each Arduino project.
+file in your home directory, or one of the other `auniter.ini` files
+in the search path described above in the section labeled *Config File*.
+
+The script can be told to look elsewhere using the `--config` command line flag.
+(Use `--config /dev/null` to indicate no config file.) This may be useful if the
+config file is checked into source control for each Arduino project.
+
+Example:
 
 ```
-$ auniter --config {path-to-config-file} subcommand {env}:{port} ...
+$ auniter --config $HOME/tmp/auniter.ini verify nano Sample.ino
 ```
 
 (The `--config` flag is an option on the `auniter.sh` command, not the
@@ -630,6 +641,30 @@ subcommand, so it must occur *before* the subcommands.)
 The `auniter.sh` accepts a `--verbose` flag, which enables verbose mode for
 those subcommands which support it. In particular, it is passed into the Arduino
 binary, which then prints out the compilation steps in extreme detail.
+
+Example:
+
+```
+$ auniter --verbose verify nano Sample.ino
+```
+
+### Additional Preprocessor Macros (-D)
+
+(Valid on the `verify`, `upload`, `upmon`, `test` subcommands).
+
+The `-D MACRO=value` flag can be given after one of the above subcommands
+to add the `macro=value` expression to the C-preprocessor.
+
+* Multiple `-D` flags can be given to define multiple macro expressions.
+* The space between the `-D` and the `MACRO=value` is *required*.
+* The MACROs defined on the command line flag are added *after* the
+  `preprocessor` flags defined in the `auniter.ini` file (see below).
+
+Example:
+
+```
+$ auniter verify -D ENABLE_SERIAL_DEBUG=1 nano Sample.ino
+```
 
 ### Default Baud Rate (baud, --baud)
 
@@ -645,6 +680,12 @@ rate to 9600:
   baud = 9600
 ```
 
+Example:
+
+```
+$ auniter upmon --baud 9600 nano:USB0 Sample.ino
+```
+
 ### Skip Missing Port (--skip_missing_port)
 
 (Valid for subcommands: `upload` and `test`)
@@ -654,11 +695,25 @@ message if the `{port}` specifier is not given. However, in continuous
 integration scripts, it is useful to simply skip the operation if the port is
 missing. This flag turns on that feature.
 
+Example:
+
+```
+$ auniter test --skip_missing_port nano:USB0,esp8266:USB1 Sample.ino
+```
+
 ### Sketchbook Path (--sketchbook)
+
+(Valid for subcommands: `verify`, `upload`, `upmon` and `test`)
 
 In continuous integration scripts, the root path of the sketchbook needs to be
 changed to a directory where the various libaries have been checked out. This
 flag changes the sketchbook directory of the Arduino IDE.
+
+Example:
+
+```
+$ auniter verify --sketchbook $HOME/MyArduinoProjects nano Sample.ino
+```
 
 ## Integration with Jenkins
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -461,6 +461,28 @@ $ auniter upmon uno:USB0 Blink.ino
 The argument list is very similar to `upload` except that `upmon` accepts
 only a single `{env}:{port}` pair.
 
+The `--output file` option (short form `-o`) can be given to the `upmon` command
+to capture the Serial output of the microcontroller to the specified `file`,
+like this:
+
+```
+$ auniter upmon -o file.txt uno:USB0 Blink.ino
+```
+
+By default, the `auniter` program has no way of knowing when the microcontroller
+has finished its output. So `auniter` will wait about 10 seconds before closing
+the file and returning control to the user. However, if the Serial output
+contains a special marker that indicates "end of file", then that marker can be
+given in the `--eof {string}`:
+
+```
+$ auniter upmon -o file.txt --eof END uno:USB0 Blink.ino
+```
+
+When the string `END` is found anywhere in the output line from microcontroller,
+the `auniter` command will close the output file and return. The string that
+contains the `END` marker will be included as the final line of the file.
+
 ## Advanced Usage
 
 The following features are useful if you are working with multiple board types,

--- a/tools/auniter.sh
+++ b/tools/auniter.sh
@@ -631,7 +631,8 @@ function run_save() {
     local eof="$3"
     local output="$4"
 
-    $DIRNAME/serial_monitor.py --monitor --eof "$eof" | tee "$output"
+    $DIRNAME/serial_monitor.py --monitor --port $port --eof "$eof" |
+        tee "$output"
 }
 
 # Combination of 'upload' then 'monitor' if upload goes ok.

--- a/tools/run_arduino.sh
+++ b/tools/run_arduino.sh
@@ -34,8 +34,8 @@ Flags:
     --sketchbook {path}
                     Home directory of the sketch, for resolving libraries.
     --preprocessor {flags}
-                    Build flags of the form '-DMACRO -DMACRO=value' as a single
-                    argument (must be quoted if multiple macros).
+                    Build flags of the form '-D MACRO -D MACRO=value' as a
+                    single argument (must be quoted if multiple macros).
     --preserve      Preserve /tmp/arduino* temp files for further analysis.
     --summary_file {file}
                     Send error logs to 'file'.
@@ -73,7 +73,7 @@ function verify_or_upload_using_ide() {
         $port_flag \
         $sketchbook_flag \
         $preserve \
-        --pref "'compiler.cpp.extra_flags=-DAUNITER $preprocessor'" \
+        --pref "'compiler.cpp.extra_flags=-D AUNITER $preprocessor'" \
         $file
     if ! $AUNITER_ARDUINO_BINARY \
             --$arduino_cmd_mode \
@@ -82,7 +82,7 @@ function verify_or_upload_using_ide() {
             $port_flag \
             $sketchbook_flag \
             $preserve \
-            --pref "compiler.cpp.extra_flags=-DAUNITER $preprocessor" \
+            --pref "compiler.cpp.extra_flags=-D AUNITER $preprocessor" \
             $file; then
         echo "FAILED $arduino_cmd_mode: $env $port $file" \
             | tee -a $summary_file
@@ -111,7 +111,7 @@ function verify_or_upload_using_cli() {
     local port_flag=${port:+"--port $port"}
     local arduino_cmd_mode='compile'
     local upload_flag=''
-    local extra_flags="-DAUNITER $preprocessor"
+    local extra_flags="-D AUNITER $preprocessor"
     local build_properties_value="compiler.cpp.extra_flags=$extra_flags"
     if [[ "$mode" == 'upload' || "$mode" == 'test' ]]; then
         upload_flag='--upload'

--- a/tools/serial_monitor.py
+++ b/tools/serial_monitor.py
@@ -14,7 +14,7 @@ with a status 0 if the test is successful, otherwise exits with a status 1.
 
 Usage:
     serial_monitor.py [--help] [--log_level] [--list | --test | --monitor)
-        [--port /dev/ttyPort] [--baud 115200]
+        [--port /dev/ttyPort] [--baud 115200] [--eof eof]
 
 Flags:
     --list List the known tty ports. (default)
@@ -23,6 +23,7 @@ Flags:
     --port {tty} Set the tty port.
     --baud {baud} Set the baud rate.
     --log_level (INFO|DEBUG|ERROR) Set the logging level.
+    --eof eof The End-of-File string marker.
 """
 
 import argparse
@@ -58,30 +59,38 @@ TEST_MODE_START_FOUND = 1
 TEST_MODE_END_SUMMARY_FOUND = 2
 
 
-def monitor(port, baud):
+def monitor(port, baud, eof, timeout):
     """Read the serial output and echo the lines to the STDOUT."""
     logging.info('Reading the serial port %s at %s baud' % (port, baud))
-    ser = open_port(port, baud)
+    ser = open_port(port, baud, timeout)
     logging.info('Monitoring port %s...' % port)
     try:
         while True:
             line = ser.readline()
             line = line.decode('ascii')
-            if line == '': break
+            if line == '':
+                logging.error(
+                    f"No output detected after {timeout} seconds... exiting."
+                )
+                break
+
             line = line.rstrip()
             print(line)
+            if eof and eof in line:
+                # The line with eof is *included* in the output.
+                logging.info(f"Detected '{eof}' EOF string... exiting.")
+                break
     finally:
         ser.close()
-    logging.error('No output detected after 10 seconds... exiting.')
 
 
-def validate_test(port, baud):
+def validate_test(port, baud, timeout):
     """Read and verify an AUnit test looking and matching specific lines from
     the TestRunner of AUnit in the serial output.
     """
     logging.info('Reading the AUnit test on serial port %s at %s baud' %
                  (port, baud))
-    ser = open_port(port, baud)
+    ser = open_port(port, baud, timeout)
     try:
         summary_line = ''
         test_mode = TEST_MODE_UNKNOWN
@@ -137,7 +146,7 @@ def list_ports():
         print(comport)
 
 
-def open_port(port, baud):
+def open_port(port, baud, timeout):
     """Open the given port. Boards like Teensy, Leonardo, and Micro do not
     create a virtual serial port until the Arduino program runs, so we make
     multiple attempts (NUM_ATTEMPTS) to open the port using an exponential back
@@ -145,7 +154,7 @@ def open_port(port, baud):
     """
     wait_time = WAIT_TIME_BASE
     count = 1
-    ser = serial.Serial(port=None, baudrate=baud, timeout=TIMEOUT_ON_IDLE)
+    ser = serial.Serial(port=None, baudrate=baud, timeout=timeout)
     ser.port = port
     while True:
         try:
@@ -184,6 +193,13 @@ def main():
         '--test', action='store_true', help='Verify an AUnit test')
     parser.add_argument(
         '--monitor', action='store_true', help='Monitor the serial port')
+    parser.add_argument(
+        '--eof', action='store', default='', help='End of File string')
+    parser.add_argument(
+        '--timeout',
+        action='store',
+        default=TIMEOUT_ON_IDLE,
+        help='End of File string')
     args = parser.parse_args()
 
     # Configure logging.
@@ -191,9 +207,9 @@ def main():
         level=args.log_level, format=LOG_FORMAT, datefmt=DATE_FORMAT)
 
     if args.monitor:
-        monitor(args.port, args.baud)
+        monitor(args.port, args.baud, args.eof, args.timeout)
     elif args.test:
-        validate_test(args.port, args.baud)
+        validate_test(args.port, args.baud, args.timeout)
     else:
         list_ports()
 


### PR DESCRIPTION
* 1.9 (2020-12-03)
    * Add `-D MACRO=value` flag which adds additional C-Preprocessor macros
      when using `verify`, `upload`, `upmon` and `test` subcommands. Multiple
      `-D` flags will define multiple MACROs.
    * Add `--output filename` flag (short form `-o`) to the `upmon` command. It
      captures the serial output of the microcontroller and saves it to the
      given `filename`. By default, the process ends after a 10 second timeout.
      However, if `--eof string` flag is given, the script looks for the given
      string and terminates just after it is detected in the serial output. The
      `string` itself is saved into the file. The `--output` flag could be
      useful in the `monitor` command as well, but it is not clear that it would
      be useful, so for the lack of infinite time, I have not implemented it.
