### PR TITLE
merge 1.9.1 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 * Unreleased
+    * Support `-D MACRO=value` when using `--cli` flag to invoke the ArduinoCLI
+      using the new `--build-property` flag.
+    * Add `--warnings all` flag when using `ArduinoCLI` to enable all compiler
+      warnings.
 * 1.9 (2020-12-03)
     * Add `-D MACRO=value` flag which adds additional C-Preprocessor macros
       when using `verify`, `upload`, `upmon` and `test` subcommands. Multiple

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 * Unreleased
+* 1.9.1 (2021-05-21)
     * Support `-D MACRO=value` when using `--cli` flag to invoke the ArduinoCLI
       using the new `--build-property` flag.
     * Add `--warnings all` flag when using `ArduinoCLI` to enable all compiler

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ configurations and aliases which look like this:
   preprocessor = -DAUNITER_MICRO -DAUNITER_BUTTON=3
 ```
 
-**Version**: 1.9 (2020-12-03)
+**Version**: 1.9.1 (2020-05-21)
 
 **Changelog**: [CHANGELOG.md](CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ There are 3 components to the **AUniter** package:
             flag](https://github.com/arduino/arduino-cli/issues/846), and,
         1. The Jenkins service is too brittle and cumbersome to maintain.
     * I have started to use the
-      [UnixHostDuino](https://github.com/bxparks/UnixHostDuino) project
+      EpoxyDuino (https://github.com/bxparks/EpoxyDuino) project
       more frequently as an alternative, even though it cannot handle the
       Arduino programs that depend on specific hardware.
 1. A [Badge Service](BadgeService/) running on

--- a/tools/auniter.sh
+++ b/tools/auniter.sh
@@ -501,15 +501,14 @@ function interrupted() {
     exit 1
 }
 
-# Process build (verify, upload, or test) commands.
+# Process the build command (verify, upload, or test). Depends on 'mode' to be
+# set properly ('verify', 'upload', 'test').
 function handle_build() {
-    local single=0
     cli_preprocessor=
     sketchbook_flag=
     skip_missing_port=0
     while [[ $# -gt 0 ]]; do
         case $1 in
-            --single) single=1 ;; # internal flag
             -D) shift; cli_preprocessor="$cli_preprocessor -D $1" ;;
             --sketchbook) shift; sketchbook_flag="--sketchbook $1" ;;
             --skip_missing_port) skip_missing_port=1 ;;
@@ -519,22 +518,21 @@ function handle_build() {
         shift
     done
 
+    handle_envs_and_files "$@"
+}
+
+# Usage: handle_envs_and_files {env:xxx},{env:yyy} [file ...]
+# The environments are given as a comma-separated list.
+# The files are given as a space-separated list.
+# If the file is missing, look for a '*.ino' file in the current directory.
+function handle_envs_and_files() {
     if [[ $# -lt 1 ]]; then
         echo 'No environment given'
         usage
     fi
     envs=$1
     shift
-    if [[ "$single" == 1 ]]; then
-        if [[ "$envs" =~ , ]]; then
-            echo "Multiple environments not allowed in 'upmon' command"
-            usage
-        fi
-        if [[ $# -gt 1 ]]; then
-            echo "Multiple files not allowed in 'upmon' command"
-            usage
-        fi
-    fi
+
     local files
     if [[ $# -lt 1 ]]; then
         # Check for a sketch file named *.ino in the current directory.
@@ -624,22 +622,44 @@ function run_save() {
         tee "$output"
 }
 
-# Combination of 'upload' then 'monitor' if upload goes ok.
+# Combination of 'upload' then 'monitor' if upload goes ok. Simiilar to
+# handle_build() but supports additional flags: --output and --eof.
 function handle_upmon() {
     local eof=''
     local output=''
+    cli_preprocessor=
+    sketchbook_flag=
+    skip_missing_port=0
     while [[ $# -gt 0 ]]; do
         case $1 in
             --eof) shift; eof="$1" ;;
             --output|-o) shift; output="$1" ;;
+            -D) shift; cli_preprocessor="$cli_preprocessor -D $1" ;;
+            --sketchbook) shift; sketchbook_flag="--sketchbook $1" ;;
+            --skip_missing_port) skip_missing_port=1 ;;
             -*) echo "Unknown upmon flag '$1'"; usage ;;
             *) break ;;
         esac
         shift
     done
 
+    if [[ $# -lt 1 ]]; then
+        echo 'No environment given'
+        usage
+    fi
+    envs=$1
+    shift
+    if [[ "$envs" =~ , ]]; then
+        echo "Multiple environments not allowed in 'upmon' command"
+        usage
+    fi
+    if [[ $# -gt 1 ]]; then
+        echo "Multiple files not allowed in 'upmon' command"
+        usage
+    fi
+
     mode=upload
-    handle_build --single "$@"
+    handle_envs_and_files $envs "$@"
 
     if [[ "$output" != '' ]]; then
         mode=save # setting mode not needed, but preserves consistency
@@ -718,8 +738,7 @@ function main() {
         config) print_config $config_file;;
         envs) list_envs $config_file;;
         ports) list_ports ;;
-        verify) handle_build "$@" ;;
-        compile) mode='verify'; handle_build "$@" ;;
+        verify|compile) mode='verify'; handle_build "$@" ;;
         upload) handle_build "$@" ;;
         test) handle_build "$@" ;;
         monitor|mon) handle_monitor "$@" ;;

--- a/tools/auniter.sh
+++ b/tools/auniter.sh
@@ -351,17 +351,6 @@ function process_envs() {
         # adding the '-D macro' flags given on the 'auniter.sh' command line.
         preprocessor="$preprocessor $cli_preprocessor"
 
-        # If the preprocessor directive contains quotes, then arduino-cli cannot
-        # be used due to its incorrect handling of the --build-properties flag.
-        # TODO(brian): Remove this when the ArduinoCLI finally supports
-        # preprocessor flags contains strings.
-        if [[ "$preprocessor" =~ \" && "$cli_option" == 'cli' ]]; then
-            echo "\
-The ArduinoCLI (invoked with --cli) does not support preprocessor flags
-containing strings. Use --ide flag instead"
-            exit 1
-        fi
-
         process_files "$@"
     done
 }

--- a/tools/run_arduino.sh
+++ b/tools/run_arduino.sh
@@ -124,20 +124,21 @@ $upload_flag \
 $board_flag \
 $port_flag \
 --build-property '$build_property_value' \
+--warnings all \
 $file"
 
-    # Unfortunately, arduino-cli does not parse the --build-properties flag
-    # properly if the value contains embedded quotes, which happens if the -D
-    # symbol defines a c-string (in quotes). I've tried every combination of
-    # escaping and backslashes in $build_property_value, cannot get this to
-    # work. The 'auniter.sh' will detect this condition and fail immediately
-    # before this script is called.
+    # Arduino-cli does not parse the --build-properties flag properly if the
+    # value contains embedded quotes, which happens if the -D symbol defines a
+    # c-string (in quotes). Fortunately the --build-properties flag is
+    # deprecated as of v0.14.0 in favor of --build-property flag which handles
+    # embedded quotes properly.
     if ! $AUNITER_ARDUINO_CLI \
 $verbose \
 $arduino_cmd_mode \
 $upload_flag \
 $board_flag \
 $port_flag \
+--warnings all \
 --build-property "$build_property_value" \
 $file; then
         echo "FAILED $arduino_cmd_mode: $env $port $file" \

--- a/tools/run_arduino.sh
+++ b/tools/run_arduino.sh
@@ -123,8 +123,8 @@ $arduino_cmd_mode \
 $upload_flag \
 $board_flag \
 $port_flag \
---build-property '$build_property_value' \
 --warnings all \
+--build-property '$build_property_value' \
 $file"
 
     # Arduino-cli does not parse the --build-properties flag properly if the

--- a/tools/run_arduino.sh
+++ b/tools/run_arduino.sh
@@ -112,7 +112,7 @@ function verify_or_upload_using_cli() {
     local arduino_cmd_mode='compile'
     local upload_flag=''
     local extra_flags="-D AUNITER $preprocessor"
-    local build_properties_value="compiler.cpp.extra_flags=$extra_flags"
+    local build_property_value="compiler.cpp.extra_flags=$extra_flags"
     if [[ "$mode" == 'upload' || "$mode" == 'test' ]]; then
         upload_flag='--upload'
     fi
@@ -123,13 +123,13 @@ $arduino_cmd_mode \
 $upload_flag \
 $board_flag \
 $port_flag \
---build-properties $build_properties_value \
+--build-property '$build_property_value' \
 $file"
 
     # Unfortunately, arduino-cli does not parse the --build-properties flag
     # properly if the value contains embedded quotes, which happens if the -D
     # symbol defines a c-string (in quotes). I've tried every combination of
-    # escaping and backslashes in $build_properties_value, cannot get this to
+    # escaping and backslashes in $build_property_value, cannot get this to
     # work. The 'auniter.sh' will detect this condition and fail immediately
     # before this script is called.
     if ! $AUNITER_ARDUINO_CLI \
@@ -138,7 +138,7 @@ $arduino_cmd_mode \
 $upload_flag \
 $board_flag \
 $port_flag \
---build-properties "$build_properties_value" \
+--build-property "$build_property_value" \
 $file; then
         echo "FAILED $arduino_cmd_mode: $env $port $file" \
             | tee -a $summary_file


### PR DESCRIPTION
    * Support `-D MACRO=value` when using `--cli` flag to invoke the ArduinoCLI
      using the new `--build-property` flag.
    * Add `--warnings all` flag when using `ArduinoCLI` to enable all compiler
      warnings.
