### PR TITLE
merge 1.10.0 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
     * Add `--clean` flag to `auniter.sh` which tells Arduino-CLI to clean its
       build cache. Sometimes it caches too aggressively and does not detected
       changes to Core files.
+    * Allow `--port` to be `none`, to allow an ATtiny85 to be programmed
+      through USBtinyISP instead of the serial port.
 * 1.9.1 (2021-05-21)
     * Support `-D MACRO=value` when using `--cli` flag to invoke the ArduinoCLI
       using the new `--build-property` flag.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 * Unreleased
+    * Add `--clean` flag to `auniter.sh` which tells Arduino-CLI to clean its
+      build cache. Sometimes it caches too aggressively and does not detected
+      changes to Core files.
 * 1.9.1 (2021-05-21)
     * Support `-D MACRO=value` when using `--cli` flag to invoke the ArduinoCLI
       using the new `--build-property` flag.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,40 @@
 # Changelog
 
 * Unreleased
-    * Add `--clean` flag to `auniter.sh` which tells Arduino-CLI to clean its
-      build cache. Sometimes it caches too aggressively and does not detected
-      changes to Core files.
-    * Allow `--port` to be `none`, to allow an ATtiny85 to be programmed
-      through USBtinyISP instead of the serial port.
+    * Add `--clean` flag to `auniter.sh`
+        * tells the Arduino-CLI tool to clean its build cache.
+        * Sometimes it caches too aggressively and does not detect changes to
+          third party Core files.
+    * Update `--port {value}` flag t of `auniter.sh`
+        * Allow `none` value to allow an ATtiny85 to be programmed
+          through USBtinyISP instead of the serial port.
+        * Allow glob such as `/dev/ttyACM*` or just `ACM*`.
+            * Tells the script to select the first `/dev/ttyACM*` port that
+              matches the glob.
+            * Added to support the Adafruit ItsyBitsy M4 which seems to have a
+              flaky UF2 bootloader such that new firmware is flashed at
+              `/dev/ttyACM0`, but upon reboot, the device appears at
+              `/dev/ttyACM1`, which causes lots of confusion.
+    * Add `--delay N` flag to `auniter.sh`
+        * Some boards, especially those using UF2 bootloaders, take too much
+          time to reboot, causing the serial monitor to fail with an error
+          because there is no serial port ready yet.
+        * This flag allows a short delay before the serial monitor is fired up.
+    * Update `sample.auniter.ini`
+        * Update `nodemcuv2` configuration to be compatible with latest
+          ESP8266 core software.
+        * Add additional boards, e.g. SparkFun Pro Micro, Arduino Pro Mini,
+          Seeeduino XIAO M0, Adafruit ItsyBitsy M0 and M4, Teensy 3.2
+    * Support only a single board in a single `auniter.sh` command
+        * Previously allows a comma-separate list of `{board}:{port}` arguments
+          e.g. `auniter.sh test nano:USB0,esp8266:USB1,esp32:USB2
+          SampleTest.ino`.
+        * This feature was never reliable because the USB port of a
+          microcontroller would be randomly changed by the host operating
+          system.
+        * And the workflow of compiling the firmware, flashing it, and running
+          the unit tests was far too slow, and would sometimes fail for no
+          apparent reason.
 * 1.9.1 (2021-05-21)
     * Support `-D MACRO=value` when using `--cli` flag to invoke the ArduinoCLI
       using the new `--build-property` flag.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 * Unreleased
+* 1.10.0 (2023-06-18)
     * Add `--clean` flag to `auniter.sh`
         * tells the Arduino-CLI tool to clean its build cache.
         * Sometimes it caches too aggressively and does not detect changes to

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ and build configurations which are supported by the Arduino IDE. There is no
 duplicate installs of boards and libraries because the build and upload steps go
 through the Arduino IDE binary in command line mode.
 
-There are 3 components to the **AUniter** package:
+There are 3 components to the **AUniter** package, of which 2 of them are
+obsolete, so the only remaining tool is the `auniter.sh` script:
 
 1. [`tools/auniter.sh`](tools/)
     * compile, upload, and monitor Arduino programs using a command
@@ -166,6 +167,17 @@ so I do not know if it would work on that.
   due to [Issue #4](https://github.com/bxparks/AUniter/issues/4).
 * Arduino-CLI has a broken parser for its `--build-properties` flag, so
   `-D` flags with a string does not work.
+* The `auniter.sh` is a bash script that has become far too complex. It should
+  probably be rewritten in some other language, but other options may introduce
+  their own issues:
+    * Python is a good candidate. The language is simple and maintainable,
+      but Python packaging is an incomprehensible mess. It is non-trivial
+      to create a working Python3 environment.
+    * Go language. Creates a single, statically linked binary, but it may be too
+      low-level for something like `auniter.sh`.
+    * Perl seems like a great fit. But Perl has a convoluted language that looks
+      like modem noise. It tends to produce write-only, read-never,
+      unmaintainable code that I have no tolerance for anymore.
 
 ## Alternatives Considered
 

--- a/README.md
+++ b/README.md
@@ -28,13 +28,15 @@ through the Arduino IDE binary in command line mode.
 
 There are 3 components to the **AUniter** package:
 
-1. A command line tool [`tools/auniter.sh`](tools/) that can compile and upload
-   Arduino programs. It can also upload unit tests written in
-   [AUnit](https://github.com/bxparks/AUnit) and validate the success and
-   failure of the unit tests.
-1. A locally hosted [Jenkins Integration](jenkins/) to provide Ccontinuous
-   Integration (CI) of unit tests upon changes to the source code repository.
-    * This depends on the `auniter.sh` described above.
+1. [`tools/auniter.sh`](tools/)
+    * compile, upload, and monitor Arduino programs using a command
+      line interface.
+    * can automatically run and verify unit tests written using the
+      [AUnit](https://github.com/bxparks/AUnit) testing framework
+1. [Jenkins Integration](jenkins/) (**Obsolete**)
+    * provides Continuous Integration (CI) of unit tests upon changes to the
+      source code repository.
+    * depends on the `auniter.sh` described above.
     * As of v1.8 or so, I no longer use this integration because:
         1. the Arduino IDE is simply too slow, with some of my projects taking
             1-2 hours to run through all the test suites,
@@ -42,16 +44,16 @@ There are 3 components to the **AUniter** package:
             [broken --build-properties
             flag](https://github.com/arduino/arduino-cli/issues/846), and,
         1. The Jenkins service is too brittle and cumbersome to maintain.
-    * I have started to use the
-      EpoxyDuino (https://github.com/bxparks/EpoxyDuino) project
-      more frequently as an alternative, even though it cannot handle the
-      Arduino programs that depend on specific hardware.
-1. A [Badge Service](BadgeService/) running on
-   [Google Cloud Functions](https://cloud.google.com/functions/)
-   that allows the locally hosted Jenkins system to update the status of the
-   build, so that an indicator badge can be displayed on a source control
-   repository like GitHub.
-    * This depends on the Jenkins Integration described above.
+    * I recommend using the [EpoxyDuino](https://github.com/bxparks/EpoxyDuino)
+      project to run unit tests on Linux, MacOS, or FreeBSD desktop machines.
+        * EpoxyDuino allows AUnit tests to be run inside [GitHub
+          Actions](https://docs.github.com/en/actions)
+1. A [Badge Service](BadgeService/) (**Obsolete**)
+    * runs on [Google Cloud Functions](https://cloud.google.com/functions/)
+    * allows the locally hosted Jenkins system to update the status of the
+      build, so that an indicator badge can be displayed on a source control
+      repository like GitHub.
+    * depends on the Jenkins Integration described above
     * As of v1.8 or so, I no longer use this service, because the Arduino IDE
       is too slow to handle the number of INO files that I needed to compile in
       my Continuous Integration pipeline. I may revisit this when Arduino-CLI
@@ -120,7 +122,7 @@ configurations and aliases which look like this:
   preprocessor = -DAUNITER_MICRO -DAUNITER_BUTTON=3
 ```
 
-**Version**: 1.9.1 (2020-05-21)
+**Version**: 1.9.1 (2021-05-21)
 
 **Changelog**: [CHANGELOG.md](CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ right into the
 itself. Therefore, the AUniter package is able to support all boards, libraries,
 and build configurations which are supported by the Arduino IDE. There is no
 duplicate installs of boards and libraries because the build and upload steps go
-through the Arduino IDE binary in command line mode.
+through the Arduino IDE binary in command line mode, or the Arduino CLI command
+line tool.
 
 There are 3 components to the **AUniter** package, of which 2 of them are
 obsolete, so the only remaining tool is the `auniter.sh` script:
@@ -49,7 +50,7 @@ obsolete, so the only remaining tool is the `auniter.sh` script:
       project to run unit tests on Linux, MacOS, or FreeBSD desktop machines.
         * EpoxyDuino allows AUnit tests to be run inside [GitHub
           Actions](https://docs.github.com/en/actions)
-1. A [Badge Service](BadgeService/) (**Obsolete**)
+1. [Badge Service](BadgeService/) (**Obsolete**)
     * runs on [Google Cloud Functions](https://cloud.google.com/functions/)
     * allows the locally hosted Jenkins system to update the status of the
       build, so that an indicator badge can be displayed on a source control
@@ -61,7 +62,8 @@ obsolete, so the only remaining tool is the `auniter.sh` script:
       fixes the broken parser of its `--build-properties` flag.
 
 The `auniter.sh` script uses the command line mode of the
-[Arduino IDE binary](https://github.com/arduino/Arduino/blob/master/build/shared/manpage.adoc).
+[Arduino IDE binary](https://github.com/arduino/Arduino/blob/master/build/shared/manpage.adoc),
+or the [Arduino CLI](https://arduino.github.io/arduino-cli/) command line tool.
 Here are some tasks that you can perform on the command line using the
 `auniter.sh` script (the following examples use the `auniter` alias for
 `auniter.sh` for conciseness):
@@ -93,9 +95,9 @@ Here are some tasks that you can perform on the command line using the
 
 The `auniter.sh` script uses an
 [INI file](https://en.wikipedia.org/wiki/INI_file)
-configuration file
-normally located at `$HOME/.auniter.ini`. It contains various user-defined
-configurations and aliases which look like this:
+configuration file normally located at `$HOME/.auniter.ini`. It contains various
+user-defined configurations and aliases which look like this:
+
 ```ini
 [auniter]
   monitor = picocom -b $baud --omap crlf --imap lfcrlf --echo $port
@@ -123,7 +125,9 @@ configurations and aliases which look like this:
   preprocessor = -DAUNITER_MICRO -DAUNITER_BUTTON=3
 ```
 
-**Version**: 1.9.1 (2021-05-21)
+See [sample.auniter.ini](tools/sample.auniter.ini) for a bigger example.
+
+**Version**: 1.10.0 (2023-06-18)
 
 **Changelog**: [CHANGELOG.md](CHANGELOG.md)
 
@@ -131,8 +135,9 @@ configurations and aliases which look like this:
 
 1. See [AUniter Tools](tools/) to install the `auniter.sh` command line tools.
 1. See [AUniter Jenkins Integration](jenkins/) to integrate with Jenkins.
+   (**Obsolete**)
 1. See [AUniter Badge Service](BadgeService/) to display the
-   build status in the source repository.
+   build status in the source repository. (**Obsolete**)
 
 ## System Requirements
 
@@ -240,10 +245,10 @@ The [Arduino CLI](https://github.com/arduino/arduino-cli) is currently in alpha
 stage. I did not learn about it until I had built the `AUniter` tools. It is a
 Go Lang program which interacts relatively nicely with the Arduino IDE.
 
-Version 1.8 includes an initial integration with Arduino-CLI and exposes
-that functionality through the `--cli` flag. However, the Arduino-CLI has a
-broken parser for its `--build-properties` flag, so it does not support `-D`
-flags that contain strings.
+The `--cli` flag in `auniter.sh` will cause `auniter.sh` to use the Arduino CLI
+instead of the Arduino IDE instead. Some ugly hacks were required to support the
+`-D macro=value` flag because the Arduino CLI does not support this feature
+directly.
 
 ### Arduino-Makefile
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ vastly different build environment such as
 The underlying tool is a shell wrapper around the command line abilities built
 right into the
 [Arduino IDE](https://github.com/arduino/Arduino/blob/master/build/shared/manpage.adoc)
-itself. Therefore, the AUniter package is able to support all boards, libraries,
+itself or the [Arduino CLI](https://arduino.github.io/arduino-cli/).
+Therefore, the AUniter package is able to support all boards, libraries,
 and build configurations which are supported by the Arduino IDE. There is no
 duplicate installs of boards and libraries because the build and upload steps go
 through the Arduino IDE binary in command line mode, or the Arduino CLI command

--- a/README.md
+++ b/README.md
@@ -308,13 +308,18 @@ describes how to actually to use these programs.
 
 ## Feedback and Support
 
-If you have any questions, comments, bug reports, or feature requests, please
-file a GitHub ticket or send me an email. I'd love to hear about how this
-software and its documentation can be improved. Instead of forking the
-repository to modify or add a feature for your own projects, let me have a
-chance to incorporate the change into the main repository so that your external
-dependencies are simpler and so that others can benefit. I can't promise that I
-will incorporate everything, but I will give your ideas serious consideration.
+If you have any questions, comments, or feature requests for this library,
+please use the [GitHub
+Discussions](https://github.com/bxparks/AUniter/discussions) for this project.
+If you have a bug report, please file a ticket in [GitHub
+Issues](https://github.com/bxparks/AUniter/issues). Feature requests should go
+into Discussions first because they often have alternative solutions which are
+useful to remain visible, instead of disappearing from the default view of the
+Issue tracker after the ticket is closed.
+
+Please refrain from emailing me directly unless the content is sensitive. The
+problem with email is that I cannot reference the email conversation when other
+people ask similar questions later.
 
 ## Authors
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -5,9 +5,12 @@ the [Arduino Commandline
 Interface](https://github.com/arduino/Arduino/blob/master/build/shared/manpage.adoc).
 Starting with v1.8, the `auniter.sh` script also supports the
 [Arduino-CLI](https://github.com/arduino/arduino-cli) binary. It has been
-extensively tested on Ubuntu Linux 18.04 and 20.04. It works on my MacOS 10.14.6
-(Mojave) laptop but testing is not as extensive. I do not have a machine running
-MacOS 10.15 (Catalina).
+extensively tested on Ubuntu Linux 18.04, 20.04, and 22.04. It used to work on
+my MacOS 10.14.6 (Mojave) which I can no longer test because I don't have a
+machine that runs that version. I have done some testing on MacOS 11 (Big Sur)
+and 12 (Monterey), though I don't do much software development on Macs so they
+have not been tested extensively. I have no Mac computer that can run the latest
+MacOS versions, so I am unable to test anything on those versions.
 
 The `auniter.sh` script takes advantage of the command line interface to provide
 some useful extended functionality:
@@ -25,7 +28,7 @@ started when changes to the git repository are detected, and unit tests can be
 executed on Arduino boards attached to the serial port of the local machine. The
 Jenkins dashboard can display the status of builds and tests.
 
-The `auniter.sh` script uses the a config file (often located at
+The `auniter.sh` script uses a config file (often located at
 `$HOME/.auniter.ini`) to define named *environments* that correspond to specific
 hardware devices. The environment name takes the form `env:{name}` (e.g.
 `env:nano`). The config file also allow mapping of a short alias (e.g. `uno`) to
@@ -37,13 +40,13 @@ AUnit unit test to determine if the test passed or failed.
 
 ## Installation
 
-### Ubuntu Linux (18.04, 20.04)
+### Ubuntu Linux (18.04, 20.04, 22.04)
 
 1. Install the [Arduino IDE](https://www.arduino.cc/en/Main/Software). The
-following versions have been tested: 1.8.5, 1.8.6, 1.8.7, 1.8.13.
+following versions have been tested: 1.8.5, 1.8.6, 1.8.7, 1.8.13, 1.8.19.
     * Make a note of where the `arduino/` directory is installed.
     * I usually rename the directory to contain the version number, for example,
-      `mv arduino arduino-1.8.13`.
+      `mv arduino arduino-1.8.19`.
 1. Install the [arduino-cli](https://github.com/arduino/arduino-cli).
     * Make a note of where you installed the `arduino-cli` binary.
     * I normally install it in my `$HOME/bin` directory.
@@ -61,6 +64,9 @@ following versions have been tested: 1.8.5, 1.8.6, 1.8.7, 1.8.13.
         * tested with v2016.01.0
         * `$ sudo apt install microcom`
 
+I do not use Arduino IDE 2, so I cannot give any information. I suspect that
+`auniter.sh` is no longer compatible with Arduino IDE 2.
+
 ### MacOS (10.14.6 Mojave)
 
 Most of the functionality seems to work under MacOS 10.14 (Mojave), but I have
@@ -71,7 +77,7 @@ the MacOS by default. You need to install the GNU versions as described below.
 
 1. Install [Home Brew](https://brew.sh/)
 1. Install the [Arduino IDE](https://www.arduino.cc/en/Main/Software). The
-   following versions have been tested: 1.8.13.
+   following versions have been tested: 1.8.19.
     * Make a note of where you installed the app.
 1. Install the [arduino-cli](https://github.com/arduino/arduino-cli).
     * Make a note of where you installed the `arduino-cli` binary.
@@ -122,21 +128,21 @@ At least one of these must be defined in your `$HOME/.bashrc` file.
 
 **Ubuntu Linux**
 
-The varibles will look something like this:
+The variables will look something like this:
 
 ```
-export AUNITER_ARDUINO_BINARY="$HOME/dev/arduino-1.8.13/arduino"`
+export AUNITER_ARDUINO_BINARY="$HOME/dev/arduino-1.8.19/arduino"`
 export AUNITER_ARDUINO_CLI="$HOME/bin/arduino-cli"
 ```
 
 (assuming that the Arduino IDE was installed into a directory called
-`arduino-1.8.13/`).
+`arduino-1.8.19/`).
 
 **MacOS**
 
 The variables will look something like this:
 ```
-export AUNITER_ARDUINO_BINARY="$HOME/dev/Arduino-1.8.13.app/Contents/MacOS/Arduino`
+export AUNITER_ARDUINO_BINARY="$HOME/dev/Arduino-1.8.19.app/Contents/MacOS/Arduino`
 export AUNITER_ARDUINO_CLI='/usr/local/bin/arduino-cli'
 ```
 
@@ -282,7 +288,7 @@ file, and then prints out the content of that file.
 ```
 $ auniter config
 Reading config: /home/brian/.auniter.ini
-Using IDE: AUNITER_ARDUINO_BINARY=/home/brian/dev/arduino-1.8.13/arduino
+Using IDE: AUNITER_ARDUINO_BINARY=/home/brian/dev/arduino-1.8.19/arduino
 + cat /home/brian/.auniter.ini
 [...]
 ```
@@ -815,11 +821,11 @@ There are 2 problems with the above code:
 1. If your program is composed of multiple files (one `*.ino`, and
 several `*.cpp` and `*.h` files), then you need to replicate those
 lines for each file where you need to do different things for different
-target enviroments.
+target environments.
 1. If you compile your program with the Arduino IDE, none of these `AUNITER_*`
 macros are defined, so you will hit the `#error` message.
 
-The recommended solution is to create a `config.h` file that centrallizes
+The recommended solution is to create a `config.h` file that centralizes
 the dependencies on a particular AUniter target environment, and use `#include`
 to include that file in other `*.h` and `*.cpp` files. The macro `AUNITER` is
 the one macro that is automatically defined when the `auniter.sh` script is used
@@ -864,7 +870,7 @@ In all the other `*.cpp` and `*.h` files, you would just do:
 
 * [Teensyduino](https://pjrc.com/teensy/teensyduino.html) is not
   currently supported because of
-[Issue #4](https://github.com/bxparks/AUniter/issues/4).
+  [Issue #4](https://github.com/bxparks/AUniter/issues/4).
 * When using the Arduino-CLI (through the `--cli` flag), the `preprocessor`
   flags are passed into the `arduino-cli` binary using the `--build-properties`
   flag. Unfortunately, the Arduino-CLI has a broken parser for that flag (see

--- a/tools/README.md
+++ b/tools/README.md
@@ -737,6 +737,20 @@ Example:
 $ auniter verify --sketchbook $HOME/MyArduinoProjects nano Sample.ino
 ```
 
+### Upmon Delay (--delay N)
+
+(Valid for subcommands: `upmon`
+
+Delay running the serial monitor after uploading by N seconds. Needed on some
+microcontrollers (e.g. Seeed XIAO) whose serial port is not ready to be monitor
+until a split second after flashing.
+
+Example:
+
+```
+$ auniter upmon --delay 1 xiao:ACM0 Sample.ino
+```
+
 ## Integration with Jenkins
 
 I have successfully integrated `auniter.sh` into a locally hosted

--- a/tools/README.md
+++ b/tools/README.md
@@ -170,10 +170,10 @@ your home directory. Starting with v1.8, the `auniter.ini` file is searched in
 the following order:
 
 1. Use the value of --config flag if it is given, else,
-2. Look for 'auniter.ini' in the current directory, else,
-3. Look for 'auniter.ini' in any parent directory recursively until `/`, else,
-4. Look for '$HOME/auniter.ini', else,
-5. Look for '$HOME/.auniter.ini'.
+2. Look for `auniter.ini` in the current directory, else,
+3. Look for `auniter.ini` in any parent directory recursively until `/`, else,
+4. Look for `$HOME/auniter.ini`, else,
+5. Look for `$HOME/.auniter.ini`.
 
 I typically use only a single `$HOME/.auniter.ini` file, but occasionally, it is
 useful to override the default with a project-specific `auniter.ini` file.

--- a/tools/auniter.sh
+++ b/tools/auniter.sh
@@ -571,6 +571,7 @@ function run_monitor() {
     fi
 
     # Execute the monitor command as listed in the CONFIG_FILE.
+    echo "+ $monitor"
     eval "$monitor"
 }
 

--- a/tools/auniter.sh
+++ b/tools/auniter.sh
@@ -389,6 +389,7 @@ function process_file() {
             --env $env \
             --board $board \
             --preprocessor "$preprocessor" \
+            $clean \
             $sketchbook_flag \
             $verbose \
             $preserve \
@@ -509,6 +510,7 @@ function handle_build() {
     skip_missing_port=0
     while [[ $# -gt 0 ]]; do
         case $1 in
+            --clean) clean='--clean' ;;
             -D) shift; cli_preprocessor="$cli_preprocessor -D $1" ;;
             --sketchbook) shift; sketchbook_flag="--sketchbook $1" ;;
             --skip_missing_port) skip_missing_port=1 ;;
@@ -758,6 +760,7 @@ function main() {
 mode=
 verbose=
 preserve=
+clean=
 cli_option='ide'
 config_file=
 summary_file=

--- a/tools/auniter.sh
+++ b/tools/auniter.sh
@@ -556,6 +556,7 @@ function handle_envs_and_files() {
 }
 
 function list_ports() {
+    echo "+ $DIRNAME/serial_monitor.py --list"
     $DIRNAME/serial_monitor.py --list
 }
 

--- a/tools/auniter.sh
+++ b/tools/auniter.sh
@@ -306,11 +306,14 @@ function process_env_and_port() {
 
 # If a port is not fully qualified (i.e. start with /), then append
 # "/dev/tty" to the given port. On Linux, all serial ports seem to start
-# with this prefix, so we can specify "/dev/ttyUSB0" as just "USB0".
+# with this prefix, so we can specify "/dev/ttyUSB0" as just "USB0". If
+# port is "none", then just return "none".
 function resolve_port() {
     local port_alias=$1
     if [[ $port_alias =~ ^/ ]]; then
         echo $port_alias
+    elif [[ "$port_alias" == 'none' ]]; then
+        echo 'none'
     elif [[ "$port_alias" == '' ]]; then
         echo ''
     else
@@ -398,7 +401,7 @@ function process_file() {
     else # $mode == 'test' | 'upload'
         # flock(1) returns status 1 if the lock file doesn't exist, which
         # prevents distinguishing that from failure of run_arduino.sh.
-        if [[ ! -e $port ]]; then
+        if [[ "$port" != 'none' && ! -e "$port" ]]; then
             echo "FAILED $mode: $env: cannot find port $port: $file" \
                 | tee -a $summary_file
             return

--- a/tools/run_arduino.sh
+++ b/tools/run_arduino.sh
@@ -11,7 +11,7 @@ DIRNAME=$(dirname $0)
 function usage() {
     cat <<'END'
 Usage: run_arduino.sh [--help] [--verbose] [--cli | --ide]
-    [--verify | --upload | --test] [--clean]
+    [--verify | --upload] [--clean]
     [--env {env}] [--board {board}] [--port {port}] [--baud {baud}]
     [--sketchbook {path}] [--preprocessor {flags}] [--preserve]
     [--summary_file file] file.ino
@@ -26,7 +26,6 @@ Flags:
     --cli           Use the Arduino-CLI binary given by AUNITER_ARDUINO_CLI.
     --verify        Verify the compile of the sketch file(s).
     --upload        Compile and upload the given program.
-    --test          Verify the AUnit test after uploading the program.
     --clean         Clean the Arduino CLI compiler cache (not needed for IDE).
     --env {env}     Name of the current build environment, for error messages.
     --board {fqbn}  Fully qualified board name (fqbn).
@@ -149,20 +148,6 @@ $file; then
     fi
 }
 
-# Run the serial monitor in AUnit test validation mode.
-function validate_test() {
-    local file=$1
-
-    echo # blank line
-    local cmd="$DIRNAME/serial_monitor.py --test --port $port --baud $baud"
-    echo "\$ $cmd"
-    if $cmd; then
-        echo "PASSED $mode: $env $port $file" | tee -a $summary_file
-    else
-        echo "FAILED $mode: $env $port $file" | tee -a $summary_file
-    fi
-}
-
 mode=
 board=
 port=
@@ -180,7 +165,6 @@ while [[ $# -gt 0 ]]; do
         --ide|-i) cli_option='ide' ;;
         --verify) mode='verify' ;;
         --upload) mode='upload' ;;
-        --test) mode='test' ;;
         --clean) clean='--clean' ;;
         --verbose) verbose='--verbose' ;;
         --env) shift; env=$1 ;;
@@ -209,8 +193,4 @@ elif [[ "$cli_option" == 'ide' ]]; then
 else
     echo "Unsupported cli_option '$cli_option'"
     usage
-fi
-
-if [[ "$mode" == 'test' ]]; then
-    validate_test $1
 fi

--- a/tools/run_arduino.sh
+++ b/tools/run_arduino.sh
@@ -11,7 +11,7 @@ DIRNAME=$(dirname $0)
 function usage() {
     cat <<'END'
 Usage: run_arduino.sh [--help] [--verbose] [--cli | --ide]
-    [--verify | --upload | --test]
+    [--verify | --upload | --test] [--clean]
     [--env {env}] [--board {board}] [--port {port}] [--baud {baud}]
     [--sketchbook {path}] [--preprocessor {flags}] [--preserve]
     [--summary_file file] file.ino
@@ -27,6 +27,7 @@ Flags:
     --verify        Verify the compile of the sketch file(s).
     --upload        Compile and upload the given program.
     --test          Verify the AUnit test after uploading the program.
+    --clean         Clean the Arduino CLI compiler cache (not needed for IDE).
     --env {env}     Name of the current build environment, for error messages.
     --board {fqbn}  Fully qualified board name (fqbn).
     --port {port}   Serial port device (e.g. /dev/ttyUSB0).
@@ -121,6 +122,7 @@ function verify_or_upload_using_cli() {
 $verbose \
 $arduino_cmd_mode \
 $upload_flag \
+$clean \
 $board_flag \
 $port_flag \
 --warnings all \
@@ -169,6 +171,7 @@ sketchbook=
 preprocessor=
 summary_file=
 preserve=
+clean=
 cli_option='ide'
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -178,6 +181,7 @@ while [[ $# -gt 0 ]]; do
         --verify) mode='verify' ;;
         --upload) mode='upload' ;;
         --test) mode='test' ;;
+        --clean) clean='--clean' ;;
         --verbose) verbose='--verbose' ;;
         --env) shift; env=$1 ;;
         --board) shift; board=$1 ;;

--- a/tools/sample.auniter.ini
+++ b/tools/sample.auniter.ini
@@ -6,16 +6,50 @@
   monitor = picocom -b $baud --omap crlf --imap lfcrlf --echo $port
 #  monitor = microcom -s $baud -p $port
 
-# Board aliases
+# Board aliases. These come from the --fqbn flag of the Arduino IDE or the
+# Arduino CLI. To update these values (when the 3rd party core updates the
+# flags) or to add support for new boards, configure the Arduino IDE for
+# "verbose" mode or pass the `-v` flag to the CLI, then compile a small test
+# program. Capture the debugging output and search somewhere deep in the logs
+# for a line that contains a `--fqbn` flag. Copy the value of that flag to
+# here. The `arduino-cli boards listall` command may also help.
 [boards]
+# "Arduino/Genuino Uno"
   uno = arduino:avr:uno
+# "Arduino Nano ATmega328P (Old Bootloader)"
   nano = arduino:avr:nano:cpu=atmega328old
+# "Arduino Pro or Pro Mini" "ATmega328P (5V, 16MHz)"
+  promini8 = arduino:avr:pro:cpu=8MHzatmega328
+# "Arduino Pro or Pro Mini" "ATmega328P (3.3V, 8MHz)"
+  promini16 = arduino:avr:pro:cpu=16MHzatmega328
+# "Arduino Leonardo"
   leonardo = arduino:avr:leonardo
-  promicro16 = SparkFun:avr:promicro:cpu=16MHzatmega32U4
+# "SparkFun Pro Micro" 8MHz
   promicro8 = SparkFun:avr:promicro:cpu=8MHzatmega32U4
+# "SparkFun Pro Micro" 16MHz
+  promicro16 = SparkFun:avr:promicro:cpu=16MHzatmega32U4
+# "Arduino/Genuino Mega or Mega2560"
   mega = arduino:avr:mega:cpu=atmega2560
+# "Seeedduino XIAO", SAMD21
+  xiao = Seeeduino:samd:seeed_XIAO_m0:usbstack=arduino,debug=off,sercom4=include
+# STM32 generic blue pill F103C8, using the HID bootloader
+# (https://github.com/Serasidis/STM32_HID_Bootloader). As noted on many
+# websites, many Blue Pill boards come with 128kB of flash instead of 64kB, and
+# it seems like my boards support 128kB. So let's define the board to be an
+# F103CB not F103C8 ('b' not 'eight') to get access to that 128kB.
+  stm32 = STMicroelectronics:stm32:GenF1:pnum=BLUEPILL_F103CB,upload_method=hidMethod,xserial=generic,usb=CDCgen,xusb=FS,opt=osstd,rtlib=nano
+# "Generic ESP8266 Module" for ESP01
+  esp01 = esp8266:esp8266:generic:xtal=80,vt=flash,exception=legacy,ssl=all,ResetMethod=nodemcu,CrystalFreq=26,FlashFreq=40,FlashMode=dout,eesz=1M64,led=1,sdk=nonosdk_190703,ip=lm2f,dbg=Disabled,lvl=None____,wipe=none,baud=115200
+# "NodeMCU 1.0 (ESP-12E)" for generic ESP8266 module
   nodemcuv2 = esp8266:esp8266:nodemcuv2:xtal=80,vt=flash,exception=disabled,ssl=all,eesz=4M2M,led=2,ip=lm2f,dbg=Disabled,lvl=None____,wipe=none,baud=921600
-  esp32 = esp32:esp32:esp32:PartitionScheme=default,FlashMode=qio,FlashFreq=80,FlashSize=4M,UploadSpeed=921600,DebugLevel=none
+# "ESP32 Dev Module" for DevKit V1 (I think?)
+  esp32 = esp32:esp32:esp32:PSRAM=disabled,PartitionScheme=default,CPUFreq=240,FlashMode=qio,FlashFreq=80,FlashSize=4M,UploadSpeed=921600,DebugLevel=none
+# "Adafruit ItsyBitsy M0 Express (SAMD21)"
+  itsym0 = adafruit:samd:adafruit_itsybitsy_m0:opt=small,usbstack=arduino,debug=off
+# "Adafruit ItsyBitsy M4 (SAMD51)"
+  itsym4 = adafruit:samd:adafruit_itsybitsy_m4:cache=on,speed=120,opt=small,maxqspi=50,usbstack=arduino,debug=off
+# Teensy 3.2
+  teensy32 = teensy:avr:teensy31:usb=serial,speed=96,opt=o2std,keys=en-us
 
 # Valid parameters of the [env:{environment}] section:
 #

--- a/tools/sample.auniter.ini
+++ b/tools/sample.auniter.ini
@@ -14,7 +14,7 @@
   promicro16 = SparkFun:avr:promicro:cpu=16MHzatmega32U4
   promicro8 = SparkFun:avr:promicro:cpu=8MHzatmega32U4
   mega = arduino:avr:mega:cpu=atmega2560
-  nodemcuv2 = esp8266:esp8266:nodemcuv2:CpuFrequency=80,FlashSize=4M1M,LwIPVariant=v2mss536,Debug=Disabled,DebugLevel=None____,FlashErase=none,UploadSpeed=921600
+  nodemcuv2 = esp8266:esp8266:nodemcuv2:xtal=80,vt=flash,exception=disabled,ssl=all,eesz=4M2M,led=2,ip=lm2f,dbg=Disabled,lvl=None____,wipe=none,baud=921600
   esp32 = esp32:esp32:esp32:PartitionScheme=default,FlashMode=qio,FlashFreq=80,FlashSize=4M,UploadSpeed=921600,DebugLevel=none
 
 # Valid parameters of the [env:{environment}] section:

--- a/tools/serial_monitor.py
+++ b/tools/serial_monitor.py
@@ -140,6 +140,10 @@ def validate_test(port, baud, timeout):
 
 
 # See https://stackoverflow.com/questions/12090503
+#
+# You can also run this from the command line
+# (https://stackoverflow.com/questions/69496787):
+#   $ python3 -m serial.tools.list_ports
 def list_ports():
     """List the available serial ports."""
     for comport in serial.tools.list_ports.comports():


### PR DESCRIPTION
* 1.10.0 (2023-06-18)
    * Add `--clean` flag to `auniter.sh`
        * tells the Arduino-CLI tool to clean its build cache.
        * Sometimes it caches too aggressively and does not detect changes to
          third party Core files.
    * Update `--port {value}` flag of `auniter.sh`
        * Allow `none` value to allow an ATtiny85 to be programmed
          through USBtinyISP instead of the serial port.
        * Allow glob such as `/dev/ttyACM*` or just `ACM*`.
            * Tells the script to select the first `/dev/ttyACM*` port that
              matches the glob.
            * Added to support the Adafruit ItsyBitsy M4 which seems to have a
              flaky UF2 bootloader such that new firmware is flashed at
              `/dev/ttyACM0`, but upon reboot, the device appears at
              `/dev/ttyACM1`, which causes lots of confusion.
    * Add `--delay N` flag to `auniter.sh`
        * Some boards, especially those using UF2 bootloaders, take too much
          time to reboot, causing the serial monitor to fail with an error
          because there is no serial port ready yet.
        * This flag allows a short delay before the serial monitor is fired up.
    * Update `sample.auniter.ini`
        * Update `nodemcuv2` configuration to be compatible with latest
          ESP8266 core software.
        * Add additional boards, e.g. SparkFun Pro Micro, Arduino Pro Mini,
          Seeeduino XIAO M0, Adafruit ItsyBitsy M0 and M4, Teensy 3.2
    * Support only a single board in a single `auniter.sh` command
        * Previously allows a comma-separate list of `{board}:{port}` arguments
          e.g. `auniter.sh test nano:USB0,esp8266:USB1,esp32:USB2
          SampleTest.ino`.
        * This feature was never reliable because the USB port of a
          microcontroller would be randomly changed by the host operating
          system.
        * And the workflow of compiling the firmware, flashing it, and running
          the unit tests was far too slow, and would sometimes fail for no
          apparent reason.
